### PR TITLE
Allow passing the child account id for pipelines policy updates

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -80,7 +80,8 @@ runs:
           "working_directory": "${{ inputs.working_directory }}",
           "terragrunt_command": "${{ inputs.command }} ${{ inputs.args }}",
           "pipelines_cli_version": "${{ inputs.pipelines_cli_version }}",
-          "pipelines_change_type": "${{ inputs.change_type }}"
+          "pipelines_change_type": "${{ inputs.change_type }}",
+          "child_account_id": "${{ fromJSON(inputs.additional_data).ChildAccountId }}"
           }'
     - name: Dispatch an action and get the run ID
       if: ${{ inputs.change_type == 'AccountRequested' }}


### PR DESCRIPTION
## What it is 

Adds support to parse AdditionalData to so we can assume the correct role in the correct account for pipelines policy updates