### PR TITLE
[CORE-1358] Remove pipelines cli-version input

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ This GitHub Action, named "Pipelines Dispatch," is designed to dispatch Terragru
 - `change_type` (required): The type of infrastructure change that occurred.
 - `additional_data` (optional): Additional data related to the change type.
 - `actor` (required): The GitHub actor responsible for the change.
-- `pipelines_cli_version` (required) The version of the Gruntwork Pipelines CLI to use for execution.
 
 ## Usage
 
@@ -48,7 +47,6 @@ jobs:
           change_type: 'AccountAdded'
           additional_data: '{"AccountName": "NewAccount"}'
           actor: ${{ github.actor }}
-          pipelines_cli_version: 'v0.2.0'
 ```
 
 ## Outputs

--- a/action.yml
+++ b/action.yml
@@ -54,9 +54,6 @@ inputs:
   actor:
     description: "The github actor responsible for the change"
     required: true
-  pipelines_cli_version:
-    description: The version of the Gruntwork Pipelines CLI to use
-    required: true
 
 runs:
   using: "composite"
@@ -79,7 +76,6 @@ runs:
           "infra_live_repo": "${{ github.repository }}",
           "working_directory": "${{ inputs.working_directory }}",
           "terragrunt_command": "${{ inputs.command }} ${{ inputs.args }}",
-          "pipelines_cli_version": "${{ inputs.pipelines_cli_version }}",
           "pipelines_change_type": "${{ inputs.change_type }}",
           "child_account_id": "${{ fromJSON(inputs.additional_data).ChildAccountId }}"
           }'
@@ -101,8 +97,7 @@ runs:
           "branch": "${{ inputs.branch }}",
           "infra_live_repo": "${{ github.repository }}",
           "working_directory": "${{ inputs.working_directory }}",
-          "terragrunt_command": "${{ inputs.command }} ${{ inputs.args }}",
-          "pipelines_cli_version": "${{ inputs.pipelines_cli_version }}"
+          "terragrunt_command": "${{ inputs.command }} ${{ inputs.args }}"
           }'
     - name: Dispatch an action and get the run ID
       if: ${{ inputs.change_type == 'AccountAdded' }}
@@ -122,8 +117,7 @@ runs:
           "branch": "${{ inputs.branch }}",
           "infra_live_repo": "${{ github.repository }}",
           "working_directory": "${{ inputs.working_directory }}",
-          "terragrunt_command": "${{ inputs.command }} ${{ inputs.args }}",
-          "pipelines_cli_version": "${{ inputs.pipelines_cli_version }}"
+          "terragrunt_command": "${{ inputs.command }} ${{ inputs.args }}"
           }'
 
     # Await default


### PR DESCRIPTION
Workflows now read the pipelines-cli-version from the gruntwork config in `infra-live`. See i[nfra-pipelines PR](https://github.com/gruntwork-io-team/dogfood-infrastructure-pipelines/pull/53).