### PR TITLE
Moving to configuring action in step

### DIFF
--- a/.github/workflows/test-caller.yml
+++ b/.github/workflows/test-caller.yml
@@ -56,6 +56,6 @@ jobs:
             {
               "AccountName": "new_account_name",
               "ChildAccountId": "child_account_id",
-              "TeamAccountNames": ["team_account_names"],
+              "TeamAccountNames": ["team_account_names"]
             }
           actor: "actor"

--- a/action.yml
+++ b/action.yml
@@ -341,6 +341,9 @@ runs:
           COPY="_To **re-run** the plan, push a new set of changes to this pull request’s branch._"
         fi
 
+        # TODO: Remove debug echo
+        echo "COPY=$COPY"
+
         # Post PR comment indicating terragrunt plan success/failure
         COMMENT_BODY=$'## Terragrunt Plan\n\n'"$TERRAGRUNT_STEP_EMOJI Terragrunt Plan $TERRAGRUNT_STEP_STATUS for "$'`'"$WORKING_DIR"$'`.\n\n '"$COPY"$'\n\n[View logs]('"$TERRAGRUNT_STEP_URL"$')'
         if [[ -n "$TERRAGRUNT_STEP_STATUS" ]]; then gh issue comment $PR_NUMBER --body "$COMMENT_BODY"; fi
@@ -355,7 +358,11 @@ runs:
             LINK=$'- ['"${FAILED_STEP_NAMES[$i]}"$']('"https://github.com/$REPO_OWNER/$REPO/actions/runs/$RUN_ID/job/$JOB_ID"$'#step:'"${FAILED_STEP_NUMBERS[$i]}"$':1)'
             COMMENT_BODY="$COMMENT_BODY""$LINK"$'\n'
           done
+
+          echo "COMMENT_BODY=$COMMENT_BODY"
+          echo "link=$LINK"
           gh issue comment $PR_NUMBER --body "$COMMENT_BODY"
+          echo "COMMENTED"
         fi
 
     - name: Get requesting PR number

--- a/action.yml
+++ b/action.yml
@@ -160,7 +160,7 @@ runs:
           "infra_live_repo": "${{ github.repository }}",
           "working_directory": "${{ inputs.working_directory }}",
           "terragrunt_command": "${{ inputs.command }} ${{ inputs.args }}",
-          "team_account_data": "${{ fromJSON(inputs.additional_data) }}""
+          "team_account_data": "${{ inputs.additional_data }}"
           }'
 
     # Await default workflow run

--- a/action.yml
+++ b/action.yml
@@ -390,7 +390,9 @@ runs:
           COPY="_**Apply** ran on the \`${{ github.ref_name }}\` branch after this pull request was merged._"
         else
           COPY="_To recover from the failure, check the logs, push any required changes to a new branch, then create a new pull request._"
-        fi
+
+        # TODO: Remove debug echo
+        echo "COPY=$COPY"
 
         # Post PR comment indicating terragrunt apply success/failure
         COMMENT_BODY=$'## Terragrunt Apply\n\n'"$TERRAGRUNT_STEP_EMOJI Terragrunt Apply $TERRAGRUNT_STEP_STATUS for "$'`'"$WORKING_DIR"$'`.\n\n '"$COPY"$'\n\n[View logs]('"$TERRAGRUNT_STEP_URL"$')'
@@ -406,7 +408,11 @@ runs:
             LINK=$'- ['"${FAILED_STEP_NAMES[$i]}"$']('"https://github.com/$REPO_OWNER/$REPO/actions/runs/$RUN_ID/job/$JOB_ID"$'#step:'"${FAILED_STEP_NUMBERS[$i]}"$':1)'
             COMMENT_BODY="$COMMENT_BODY""$LINK"$'\n'
           done
+
+          echo "COMMENT_BODY=$COMMENT_BODY"
+          echo "link=$LINK"
           gh issue comment $PR_NUMBER --body "$COMMENT_BODY"
+          echo "COMMENTED"
         fi
 
     - name: Open GH Issue on apply failure

--- a/action.yml
+++ b/action.yml
@@ -115,11 +115,10 @@ runs:
         workflow: create-sdlc-accounts-and-generate-baselines.yml
         workflow_inputs: '{
           "management_account": "${{ inputs.account_id }}",
-          "new_account_name": "${{ fromJSON(inputs.additional_data).AccountName }}",
           "branch": "${{ inputs.branch }}",
           "infra_live_repo": "${{ github.repository }}",
           "working_directory": "${{ inputs.working_directory }}",
-          "terragrunt_command": "${{ inputs.command }} ${{ inputs.args }}"
+          "terragrunt_command": "${{ inputs.command }} ${{ inputs.args }}",
           "team_account_names": "${{ fromJSON(inputs.additional_data).TeamAccountNames }}"
           }'
     - name: Dispatch account-added workflow and get the run ID
@@ -160,7 +159,7 @@ runs:
           "branch": "${{ inputs.branch }}",
           "infra_live_repo": "${{ github.repository }}",
           "working_directory": "${{ inputs.working_directory }}",
-          "terragrunt_command": "${{ inputs.command }} ${{ inputs.args }}"
+          "terragrunt_command": "${{ inputs.command }} ${{ inputs.args }}",
           "team_account_data": "${{ fromJSON(inputs.additional_data) }}""
           }'
 

--- a/action.yml
+++ b/action.yml
@@ -74,7 +74,7 @@ runs:
         COMMAND: ${{ inputs.command }}
         ARGS: ${{ inputs.args }}
         CHILD_ACCOUNT_ID: ${{ fromJSON(inputs.additional_data).ChildAccountId }}
-        TEAM_ACCOUNT_NAMES: "${{ fromJSON(inputs.additional_data).TeamAccountNames }}"
+        TEAM_ACCOUNT_NAMES: "${{ toJSON(fromJSON(inputs.additional_data).TeamAccountNames) }}"
       run: |
         if [[ "$CHANGE_TYPE" == "AccountRequested" ]]; then
           echo "workflow=create-account-and-generate-baselines.yml" >> "$GITHUB_OUTPUT"

--- a/action.yml
+++ b/action.yml
@@ -160,7 +160,7 @@ runs:
           "infra_live_repo": "${{ github.repository }}",
           "working_directory": "${{ inputs.working_directory }}",
           "terragrunt_command": "${{ inputs.command }} ${{ inputs.args }}",
-          "team_account_data": "${{ inputs.additional_data }}"
+          "team_account_data": ${{ inputs.additional_data }}
           }'
 
     # Await default workflow run

--- a/action.yml
+++ b/action.yml
@@ -397,30 +397,30 @@ runs:
           COPY="_**Apply** ran on the \`${{ github.ref_name }}\` branch after this pull request was merged._"
         else
           COPY="_To recover from the failure, check the logs, push any required changes to a new branch, then create a new pull request._"
+        fi
 
-          # TODO: Remove debug echo
-          echo "COPY=$COPY"
-  
-          # Post PR comment indicating terragrunt apply success/failure
-          COMMENT_BODY=$'## Terragrunt Apply\n\n'"$TERRAGRUNT_STEP_EMOJI Terragrunt Apply $TERRAGRUNT_STEP_STATUS for "$'`'"$WORKING_DIR"$'`.\n\n '"$COPY"$'\n\n[View logs]('"$TERRAGRUNT_STEP_URL"$')'
-          if [[ -n "$TERRAGRUNT_STEP_STATUS" ]]; then gh issue comment $PR_NUMBER --body "$COMMENT_BODY"; fi
-  
-          # If steps other than terragrunt apply failed, post PR comment about a pipeline failure.
-          # Include links to each of the failed steps.
-          if [[ -n "$FAILED_STEPS" ]]; then
-            readarray -t FAILED_STEP_NUMBERS < <(echo $FAILED_STEPS | jq -r .number)
-            readarray -t FAILED_STEP_NAMES < <(echo $FAILED_STEPS | jq -r .name)
-            COMMENT_BODY=$'## Pipelines Run Failed\n\n:x: Pipelines run failed for `'"$WORKING_DIR"$'`.\n\nInspect the logs associated with each of the following failures to learn the details of each failure:\n\n'
-            for i in "${!FAILED_STEP_NUMBERS[@]}"; do
-              LINK=$'- ['"${FAILED_STEP_NAMES[$i]}"$']('"https://github.com/$REPO_OWNER/$REPO/actions/runs/$RUN_ID/job/$JOB_ID"$'#step:'"${FAILED_STEP_NUMBERS[$i]}"$':1)'
-              COMMENT_BODY="$COMMENT_BODY""$LINK"$'\n'
-            done
-  
-            echo "COMMENT_BODY=$COMMENT_BODY"
-            echo "link=$LINK"
-            gh issue comment $PR_NUMBER --body "$COMMENT_BODY"
-            echo "COMMENTED"
-          fi
+        # TODO: Remove debug echo
+        echo "COPY=$COPY"
+
+        # Post PR comment indicating terragrunt apply success/failure
+        COMMENT_BODY=$'## Terragrunt Apply\n\n'"$TERRAGRUNT_STEP_EMOJI Terragrunt Apply $TERRAGRUNT_STEP_STATUS for "$'`'"$WORKING_DIR"$'`.\n\n '"$COPY"$'\n\n[View logs]('"$TERRAGRUNT_STEP_URL"$')'
+        if [[ -n "$TERRAGRUNT_STEP_STATUS" ]]; then gh issue comment $PR_NUMBER --body "$COMMENT_BODY"; fi
+
+        # If steps other than terragrunt apply failed, post PR comment about a pipeline failure.
+        # Include links to each of the failed steps.
+        if [[ -n "$FAILED_STEPS" ]]; then
+          readarray -t FAILED_STEP_NUMBERS < <(echo $FAILED_STEPS | jq -r .number)
+          readarray -t FAILED_STEP_NAMES < <(echo $FAILED_STEPS | jq -r .name)
+          COMMENT_BODY=$'## Pipelines Run Failed\n\n:x: Pipelines run failed for `'"$WORKING_DIR"$'`.\n\nInspect the logs associated with each of the following failures to learn the details of each failure:\n\n'
+          for i in "${!FAILED_STEP_NUMBERS[@]}"; do
+            LINK=$'- ['"${FAILED_STEP_NAMES[$i]}"$']('"https://github.com/$REPO_OWNER/$REPO/actions/runs/$RUN_ID/job/$JOB_ID"$'#step:'"${FAILED_STEP_NUMBERS[$i]}"$':1)'
+            COMMENT_BODY="$COMMENT_BODY""$LINK"$'\n'
+          done
+
+          echo "COMMENT_BODY=$COMMENT_BODY"
+          echo "link=$LINK"
+          gh issue comment $PR_NUMBER --body "$COMMENT_BODY"
+          echo "COMMENTED"
         fi
 
     - name: Open GH Issue on apply failure

--- a/action.yml
+++ b/action.yml
@@ -160,7 +160,7 @@ runs:
           "infra_live_repo": "${{ github.repository }}",
           "working_directory": "${{ inputs.working_directory }}",
           "terragrunt_command": "${{ inputs.command }} ${{ inputs.args }}",
-          "team_account_data": ${{ inputs.additional_data }}
+          "team_account_data": ${{ toJSON(inputs.additional_data) }}
           }'
 
     # Await default workflow run

--- a/action.yml
+++ b/action.yml
@@ -73,6 +73,7 @@ runs:
         WORKING_DIRECTORY: ${{ inputs.working_directory }}
         COMMAND: ${{ inputs.command }}
         ARGS: ${{ inputs.args }}
+        CHILD_ACCOUNT_ID: ${{ fromJSON(inputs.additional_data).ChildAccountId }}
       run: |
         if [[ "$CHANGE_TYPE" == "AccountRequested" ]]; then
           echo "workflow=create-account-and-generate-baselines.yml" >> "$GITHUB_OUTPUT"
@@ -154,12 +155,16 @@ runs:
             --arg infra_live_repo "$INFRA_LIVE_REPO" \
             --arg working_directory "$WORKING_DIRECTORY" \
             --arg terragrunt_command "$COMMAND $ARGS" \
+            --arg pipelines_change_type "$CHANGE_TYPE" \
+            --arg child_account_id "$CHILD_ACCOUNT_ID" \
             '{
               "account": $account,
               "branch": $branch,
               "infra_live_repo": $infra_live_repo,
               "working_directory": $working_directory,
-              "terragrunt_command": $terragrunt_command
+              "terragrunt_command": $terragrunt_command,
+              "pipelines_change_type": $pipelines_change_type,
+              "child_account_id": $child_account_id
             }'
           )" >> "$GITHUB_OUTPUT"
         fi

--- a/action.yml
+++ b/action.yml
@@ -205,7 +205,7 @@ runs:
         ACCOUNT_ID: ${{ inputs.account_id }}
         REPO: ${{ inputs.repo }}
         REPO_OWNER: ${{ inputs.repo_owner }}
-      run: echo "::notice ::Completed $COMMAND for $WORKING_DIR in acct $ACC0UNT_ID%0AFor details see https://github.com/$REPO_OWNER/$REPO/actions/runs/${{ steps.return_dispatch.outputs.run_id }}"
+      run: echo "::notice ::Completed $COMMAND for $WORKING_DIR in acct $ACCOUNT_ID%0AFor details see https://github.com/$REPO_OWNER/$REPO/actions/runs/${{ steps.return_dispatch.outputs.run_id }}"
 
     - name: Get Job ID & Terragrunt Run URL
       if: ${{ always() }} # This ensures this step always runs regardless of failure of previous step

--- a/action.yml
+++ b/action.yml
@@ -40,7 +40,9 @@ inputs:
       - EnvCommonDeleted
       - EnvCommonAdded
       - AccountRequested
+      - TeamAccountsRequested
       - AccountAdded
+      - TeamAccountsAdded
       - AccountChanged
       - PipelinesPermissionAdded
       - PipelinesPermissionChanged
@@ -58,8 +60,8 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Dispatch an action and get the run ID
-      if: ${{ !contains(fromJSON('["AccountRequested", "AccountAdded"]'), inputs.change_type)}}
+    - name: Dispatch default workflow and get the run ID
+      if: ${{ !contains(fromJSON('["AccountRequested", "AccountAdded", "TeamAccountsRequested", "TeamAccountsAdded"]'), inputs.change_type)}}
       env:
         GH_TOKEN: ${{ inputs.infra_pipelines_token }}
       uses: codex-/return-dispatch@v1.10.0
@@ -79,7 +81,7 @@ runs:
           "pipelines_change_type": "${{ inputs.change_type }}",
           "child_account_id": "${{ fromJSON(inputs.additional_data).ChildAccountId }}"
           }'
-    - name: Dispatch an action and get the run ID
+    - name: Dispatch account-requested workflow and get the run ID
       if: ${{ inputs.change_type == 'AccountRequested' }}
       env:
         GH_TOKEN: ${{ inputs.infra_pipelines_token }}
@@ -99,7 +101,28 @@ runs:
           "working_directory": "${{ inputs.working_directory }}",
           "terragrunt_command": "${{ inputs.command }} ${{ inputs.args }}"
           }'
-    - name: Dispatch an action and get the run ID
+    - name: Dispatch team-accounts-requested workflow and get the run ID
+      if: ${{ inputs.change_type == 'TeamAccountsRequested' }}
+      env:
+        GH_TOKEN: ${{ inputs.infra_pipelines_token }}
+      uses: codex-/return-dispatch@v1.10.0
+      id: return_dispatch_team_accts_req
+      with:
+        token: ${{ inputs.infra_pipelines_token }}
+        ref: "refs/heads/main"
+        repo: ${{ inputs.repo }}
+        owner: ${{ inputs.repo_owner }}
+        workflow: create-sdlc-accounts-and-generate-baselines.yml
+        workflow_inputs: '{
+          "management_account": "${{ inputs.account_id }}",
+          "new_account_name": "${{ fromJSON(inputs.additional_data).AccountName }}",
+          "branch": "${{ inputs.branch }}",
+          "infra_live_repo": "${{ github.repository }}",
+          "working_directory": "${{ inputs.working_directory }}",
+          "terragrunt_command": "${{ inputs.command }} ${{ inputs.args }}"
+          "team_account_names": "${{ fromJSON(inputs.additional_data).TeamAccountNames }}"
+          }'
+    - name: Dispatch account-added workflow and get the run ID
       if: ${{ inputs.change_type == 'AccountAdded' }}
       env:
         GH_TOKEN: ${{ inputs.infra_pipelines_token }}
@@ -119,10 +142,31 @@ runs:
           "working_directory": "${{ inputs.working_directory }}",
           "terragrunt_command": "${{ inputs.command }} ${{ inputs.args }}"
           }'
+    - name: Dispatch team-accounts-added workflow and get the run ID
+      if: ${{ inputs.change_type == 'TeamAccountsAdded' }}
+      env:
+        GH_TOKEN: ${{ inputs.infra_pipelines_token }}
+      uses: codex-/return-dispatch@v1.10.0
+      id: return_dispatch_team_accts_add
+      with:
+        token: ${{ inputs.infra_pipelines_token }}
+        ref: "refs/heads/main"
+        repo: ${{ inputs.repo }}
+        owner: ${{ inputs.repo_owner }}
+        workflow: apply-new-sdlc-accounts-baseline.yml
+        workflow_inputs: '{
+          "management_account": "${{ inputs.account_id }}",
+          "child_account": "${{ fromJSON(inputs.additional_data).ChildAccountId }}",
+          "branch": "${{ inputs.branch }}",
+          "infra_live_repo": "${{ github.repository }}",
+          "working_directory": "${{ inputs.working_directory }}",
+          "terragrunt_command": "${{ inputs.command }} ${{ inputs.args }}"
+          "team_account_data": "${{ fromJSON(inputs.additional_data) }}""
+          }'
 
-    # Await default
+    # Await default workflow run
     - name: Await Run ID ${{ steps.return_dispatch.outputs.run_id }}
-      if: ${{ !contains(fromJSON('["AccountRequested", "AccountAdded"]'), inputs.change_type)}}
+      if: ${{ !contains(fromJSON('["AccountRequested", "AccountAdded", "TeamAccountsRequested", "TeamAccountsAdded"]'), inputs.change_type)}}
       env:
         GH_TOKEN: ${{ inputs.infra_pipelines_token }}
       uses: Codex-/await-remote-run@v1.9.0
@@ -135,7 +179,7 @@ runs:
         poll_interval_ms: 5000 # Optional
 
     - name: Completed
-      if: ${{ always() && !contains(fromJSON('["AccountRequested", "AccountAdded"]'), inputs.change_type)}}
+      if: ${{ always() && !contains(fromJSON('["AccountRequested", "AccountAdded", "TeamAccountsRequested", "TeamAccountsAdded"]'), inputs.change_type)}}
       shell: bash
       env:
         COMMAND: ${{ inputs.command }}
@@ -145,7 +189,7 @@ runs:
         REPO_OWNER: ${{ inputs.repo_owner }}
       run: echo "::notice ::Completed $COMMAND for $WORKING_DIR in acct $ACC0UNT_ID%0AFor details see https://github.com/$REPO_OWNER/$REPO/actions/runs/${{ steps.return_dispatch.outputs.run_id }}"
 
-    # Await account request
+    # Await account-requested workflow run
     - name: Await Acct Req Run ID ${{ steps.return_dispatch_acct_req.outputs.run_id }}
       if: ${{ always() && inputs.change_type == 'AccountRequested' }}
       env:
@@ -170,7 +214,32 @@ runs:
         REPO_OWNER: ${{ inputs.repo_owner }}
       run: echo "::notice ::Completed $COMMAND for $WORKING_DIR in acct $ACCOUNT_ID%0AFor details see https://github.com/$REPO_OWNER/$REPO/actions/runs/${{ steps.return_dispatch_acct_req.outputs.run_id }}"
 
-    # Await account added
+    # Await team-accounts-requested workflow run
+    - name: Await Acct Req Run ID ${{ steps.return_dispatch_team_accts_req.outputs.run_id }}
+      if: ${{ always() && inputs.change_type == 'TeamAccountsRequested' }}
+      env:
+        GH_TOKEN: ${{ inputs.infra_pipelines_token }}
+      uses: Codex-/await-remote-run@v1.9.0
+      with:
+        token: ${{ inputs.infra_pipelines_token }}
+        repo: ${{ inputs.repo }}
+        owner: ${{ inputs.repo_owner }}
+        run_id: ${{ steps.return_dispatch_team_accts_req.outputs.run_id }}
+        run_timeout_seconds: 3600 # one hour
+        poll_interval_ms: 5000 # Optional
+
+    - name: Completed Team Accounts Requested workflow
+      if: ${{ always() && inputs.change_type == 'TeamAccountsRequested' }}
+      shell: bash
+      env:
+        COMMAND: ${{ inputs.command }}
+        WORKING_DIR: ${{ inputs.working_directory }}
+        ACCOUNT_ID: ${{ inputs.account_id }}
+        REPO: ${{ inputs.repo }}
+        REPO_OWNER: ${{ inputs.repo_owner }}
+      run: echo "::notice ::Completed $COMMAND for $WORKING_DIR in acct $ACCOUNT_ID%0AFor details see https://github.com/$REPO_OWNER/$REPO/actions/runs/${{ steps.return_dispatch_team_accts_req.outputs.run_id }}"
+
+    # Await account-added workflow run
     - name: Await Acct Add Run ID ${{ steps.return_dispatch_acct_add.outputs.run_id }}
       if: ${{ always() && inputs.change_type == 'AccountAdded' }}
       env:
@@ -189,6 +258,25 @@ runs:
       shell: bash
       run: echo "::notice ::Completed ${{ inputs.command }} for ${{ inputs.working_directory }} in acct ${{ inputs.account_id }}%0AFor details see https://github.com/${{ inputs.repo_owner }}/${{ inputs.repo }}/actions/runs/${{ steps.return_dispatch_acct_add.outputs.run_id }}"
 
+    # Await team-accounts-added workflow run
+    - name: Await Acct Add Run ID ${{ steps.return_dispatch_team_accts_add.outputs.run_id }}
+      if: ${{ always() && inputs.change_type == 'TeamAccountsAdded' }}
+      env:
+        GH_TOKEN: ${{ inputs.infra_pipelines_token }}
+      uses: Codex-/await-remote-run@v1.9.0
+      with:
+        token: ${{ inputs.infra_pipelines_token }}
+        repo: ${{ inputs.repo }}
+        owner: ${{ inputs.repo_owner }}
+        run_id: ${{ steps.return_dispatch_team_accts_add.outputs.run_id }}
+        run_timeout_seconds: 3600 # one hour
+        poll_interval_ms: 5000 # Optional
+
+    - name: Completed Team Accounts Added workflow
+      if: ${{ always() && inputs.change_type == 'TeamAccountsAdded' }}
+      shell: bash
+      run: echo "::notice ::Completed ${{ inputs.command }} for ${{ inputs.working_directory }} in acct ${{ inputs.account_id }}%0AFor details see https://github.com/${{ inputs.repo_owner }}/${{ inputs.repo }}/actions/runs/${{ steps.return_dispatch_team_accts_add.outputs.run_id }}"
+
     - name: Get Job ID & Terragrunt Run URL
       if: ${{ always() }} # This ensures this step always runs regardless of failure of previous step
       id: jobs_data
@@ -201,6 +289,8 @@ runs:
         RUN_ID=${{ steps.return_dispatch.outputs.run_id }}
         if [[ -z "$RUN_ID" ]]; then RUN_ID=${{ steps.return_dispatch_acct_req.outputs.run_id }}; fi
         if [[ -z "$RUN_ID" ]]; then RUN_ID=${{ steps.return_dispatch_acct_add.outputs.run_id }}; fi
+        if [[ -z "$RUN_ID" ]]; then RUN_ID=${{ steps.return_dispatch_team_accts_req.outputs.run_id }}; fi
+        if [[ -z "$RUN_ID" ]]; then RUN_ID=${{ steps.return_dispatch_team_accts_add.outputs.run_id }}; fi
         JOB_ID="$(gh api /repos/$REPO_OWNER/$REPO/actions/runs/$RUN_ID/jobs | jq .jobs[0].id)"
         JOB_OUTPUT=$(gh api /repos/$REPO_OWNER/$REPO/actions/jobs/$JOB_ID)
         STEP_NUMBER=$(echo "$JOB_OUTPUT" | jq -c '[.steps[] | select(.name | startswith("Run terragrunt")).number] | last')

--- a/action.yml
+++ b/action.yml
@@ -74,6 +74,7 @@ runs:
         COMMAND: ${{ inputs.command }}
         ARGS: ${{ inputs.args }}
         CHILD_ACCOUNT_ID: ${{ fromJSON(inputs.additional_data).ChildAccountId }}
+        TEAM_ACCOUNT_NAMES: ${{ fromJSON(inputs.additional_data).TeamAccountNames }}
       run: |
         if [[ "$CHANGE_TYPE" == "AccountRequested" ]]; then
           echo "workflow=create-account-and-generate-baselines.yml" >> "$GITHUB_OUTPUT"

--- a/action.yml
+++ b/action.yml
@@ -155,7 +155,6 @@ runs:
         workflow: apply-new-sdlc-accounts-baseline.yml
         workflow_inputs: '{
           "management_account": "${{ inputs.account_id }}",
-          "child_account": "${{ fromJSON(inputs.additional_data).ChildAccountId }}",
           "branch": "${{ inputs.branch }}",
           "infra_live_repo": "${{ github.repository }}",
           "working_directory": "${{ inputs.working_directory }}",

--- a/action.yml
+++ b/action.yml
@@ -398,28 +398,29 @@ runs:
         else
           COPY="_To recover from the failure, check the logs, push any required changes to a new branch, then create a new pull request._"
 
-        # TODO: Remove debug echo
-        echo "COPY=$COPY"
-
-        # Post PR comment indicating terragrunt apply success/failure
-        COMMENT_BODY=$'## Terragrunt Apply\n\n'"$TERRAGRUNT_STEP_EMOJI Terragrunt Apply $TERRAGRUNT_STEP_STATUS for "$'`'"$WORKING_DIR"$'`.\n\n '"$COPY"$'\n\n[View logs]('"$TERRAGRUNT_STEP_URL"$')'
-        if [[ -n "$TERRAGRUNT_STEP_STATUS" ]]; then gh issue comment $PR_NUMBER --body "$COMMENT_BODY"; fi
-
-        # If steps other than terragrunt apply failed, post PR comment about a pipeline failure.
-        # Include links to each of the failed steps.
-        if [[ -n "$FAILED_STEPS" ]]; then
-          readarray -t FAILED_STEP_NUMBERS < <(echo $FAILED_STEPS | jq -r .number)
-          readarray -t FAILED_STEP_NAMES < <(echo $FAILED_STEPS | jq -r .name)
-          COMMENT_BODY=$'## Pipelines Run Failed\n\n:x: Pipelines run failed for `'"$WORKING_DIR"$'`.\n\nInspect the logs associated with each of the following failures to learn the details of each failure:\n\n'
-          for i in "${!FAILED_STEP_NUMBERS[@]}"; do
-            LINK=$'- ['"${FAILED_STEP_NAMES[$i]}"$']('"https://github.com/$REPO_OWNER/$REPO/actions/runs/$RUN_ID/job/$JOB_ID"$'#step:'"${FAILED_STEP_NUMBERS[$i]}"$':1)'
-            COMMENT_BODY="$COMMENT_BODY""$LINK"$'\n'
-          done
-
-          echo "COMMENT_BODY=$COMMENT_BODY"
-          echo "link=$LINK"
-          gh issue comment $PR_NUMBER --body "$COMMENT_BODY"
-          echo "COMMENTED"
+          # TODO: Remove debug echo
+          echo "COPY=$COPY"
+  
+          # Post PR comment indicating terragrunt apply success/failure
+          COMMENT_BODY=$'## Terragrunt Apply\n\n'"$TERRAGRUNT_STEP_EMOJI Terragrunt Apply $TERRAGRUNT_STEP_STATUS for "$'`'"$WORKING_DIR"$'`.\n\n '"$COPY"$'\n\n[View logs]('"$TERRAGRUNT_STEP_URL"$')'
+          if [[ -n "$TERRAGRUNT_STEP_STATUS" ]]; then gh issue comment $PR_NUMBER --body "$COMMENT_BODY"; fi
+  
+          # If steps other than terragrunt apply failed, post PR comment about a pipeline failure.
+          # Include links to each of the failed steps.
+          if [[ -n "$FAILED_STEPS" ]]; then
+            readarray -t FAILED_STEP_NUMBERS < <(echo $FAILED_STEPS | jq -r .number)
+            readarray -t FAILED_STEP_NAMES < <(echo $FAILED_STEPS | jq -r .name)
+            COMMENT_BODY=$'## Pipelines Run Failed\n\n:x: Pipelines run failed for `'"$WORKING_DIR"$'`.\n\nInspect the logs associated with each of the following failures to learn the details of each failure:\n\n'
+            for i in "${!FAILED_STEP_NUMBERS[@]}"; do
+              LINK=$'- ['"${FAILED_STEP_NAMES[$i]}"$']('"https://github.com/$REPO_OWNER/$REPO/actions/runs/$RUN_ID/job/$JOB_ID"$'#step:'"${FAILED_STEP_NUMBERS[$i]}"$':1)'
+              COMMENT_BODY="$COMMENT_BODY""$LINK"$'\n'
+            done
+  
+            echo "COMMENT_BODY=$COMMENT_BODY"
+            echo "link=$LINK"
+            gh issue comment $PR_NUMBER --body "$COMMENT_BODY"
+            echo "COMMENTED"
+          fi
         fi
 
     - name: Open GH Issue on apply failure

--- a/action.yml
+++ b/action.yml
@@ -157,7 +157,6 @@ runs:
           "management_account": "${{ inputs.account_id }}",
           "branch": "${{ inputs.branch }}",
           "infra_live_repo": "${{ github.repository }}",
-          "working_directory": "${{ inputs.working_directory }}",
           "terragrunt_command": "${{ inputs.command }} ${{ inputs.args }}",
           "team_account_data": ${{ toJSON(inputs.additional_data) }}
           }'

--- a/action.yml
+++ b/action.yml
@@ -75,6 +75,7 @@ runs:
         ARGS: ${{ inputs.args }}
         CHILD_ACCOUNT_ID: ${{ fromJSON(inputs.additional_data).ChildAccountId }}
         TEAM_ACCOUNT_NAMES: "${{ toJSON(fromJSON(inputs.additional_data).TeamAccountNames) }}"
+        TEAM_ACCOUNT_DATA: ${{ inputs.additional_data }}
       run: |
         if [[ "$CHANGE_TYPE" == "AccountRequested" ]]; then
           echo "workflow=create-account-and-generate-baselines.yml" >> "$GITHUB_OUTPUT"

--- a/action.yml
+++ b/action.yml
@@ -211,10 +211,6 @@ runs:
       shell: bash
       run: |
         RUN_ID=${{ steps.return_dispatch.outputs.run_id }}
-        if [[ -z "$RUN_ID" ]]; then RUN_ID=${{ steps.return_dispatch_acct_req.outputs.run_id }}; fi
-        if [[ -z "$RUN_ID" ]]; then RUN_ID=${{ steps.return_dispatch_acct_add.outputs.run_id }}; fi
-        if [[ -z "$RUN_ID" ]]; then RUN_ID=${{ steps.return_dispatch_team_accts_req.outputs.run_id }}; fi
-        if [[ -z "$RUN_ID" ]]; then RUN_ID=${{ steps.return_dispatch_team_accts_add.outputs.run_id }}; fi
         JOB_ID="$(gh api /repos/$REPO_OWNER/$REPO/actions/runs/$RUN_ID/jobs | jq .jobs[0].id)"
         JOB_OUTPUT=$(gh api /repos/$REPO_OWNER/$REPO/actions/jobs/$JOB_ID)
         STEP_NUMBER=$(echo "$JOB_OUTPUT" | jq -c '[.steps[] | select(.name | startswith("Run terragrunt")).number] | last')

--- a/action.yml
+++ b/action.yml
@@ -157,6 +157,7 @@ runs:
           "management_account": "${{ inputs.account_id }}",
           "branch": "${{ inputs.branch }}",
           "infra_live_repo": "${{ github.repository }}",
+          "working_directory": "${{ inputs.working_directory }}",
           "terragrunt_command": "${{ inputs.command }} ${{ inputs.args }}",
           "team_account_data": ${{ toJSON(inputs.additional_data) }}
           }'

--- a/action.yml
+++ b/action.yml
@@ -74,7 +74,7 @@ runs:
         COMMAND: ${{ inputs.command }}
         ARGS: ${{ inputs.args }}
         CHILD_ACCOUNT_ID: ${{ fromJSON(inputs.additional_data).ChildAccountId }}
-        TEAM_ACCOUNT_NAMES: ${{ fromJSON(inputs.additional_data).TeamAccountNames }}
+        TEAM_ACCOUNT_NAMES: "${{ fromJSON(inputs.additional_data).TeamAccountNames }}"
       run: |
         if [[ "$CHANGE_TYPE" == "AccountRequested" ]]; then
           echo "workflow=create-account-and-generate-baselines.yml" >> "$GITHUB_OUTPUT"

--- a/action.yml
+++ b/action.yml
@@ -61,8 +61,110 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Setup Action Configurations
+      id: setup-action-configurations
+      shell: bash
+      env:
+        CHANGE_TYPE: ${{ inputs.change_type }}
+        MANAGEMENT_ACCOUNT: ${{ inputs.account_id }}
+        NEW_ACCOUNT_NAME: ${{ fromJSON(inputs.additional_data).AccountName }}
+        BRANCH: ${{ inputs.branch }}
+        INFRA_LIVE_REPO: ${{ github.repository }}
+        WORKING_DIRECTORY: ${{ inputs.working_directory }}
+        COMMAND: ${{ inputs.command }}
+        ARGS: ${{ inputs.args }}
+      run: |
+        if [[ "$CHANGE_TYPE" == "AccountRequested" ]]; then
+          echo "workflow=create-account-and-generate-baselines.yml" >> "$GITHUB_OUTPUT"
+          echo "workflow_inputs=$(jq -c -n \
+            --arg management_account "$MANAGEMENT_ACCOUNT" \
+            --arg new_account_name "$NEW_ACCOUNT_NAME" \
+            --arg branch "$BRANCH" \
+            --arg infra_live_repo "$INFRA_LIVE_REPO" \
+            --arg working_directory "$WORKING_DIRECTORY" \
+            --arg terragrunt_command "$COMMAND $ARGS" \
+            '{
+              "management_account": $management_account,
+              "new_account_name": $new_account_name,
+              "branch": $branch,
+              "infra_live_repo": $infra_live_repo,
+              "working_directory": $working_directory,
+              "terragrunt_command": $terragrunt_command
+            }')" >> "$GITHUB_OUTPUT"
+          )"
+        elif [[ "$CHANGE_TYPE" == "AccountAdded" ]]; then
+          echo "workflow=apply-new-account-baseline.yml" >> "$GITHUB_OUTPUT"
+          echo "workflow_inputs=$(jq -c -n \
+            --arg management_account "$MANAGEMENT_ACCOUNT" \
+            --arg child_account "$NEW_ACCOUNT_NAME" \
+            --arg branch "$BRANCH" \
+            --arg infra_live_repo "$INFRA_LIVE_REPO" \
+            --arg working_directory "$WORKING_DIRECTORY" \
+            --arg terragrunt_command "$COMMAND $ARGS" \
+            '{
+              "management_account": $management_account,
+              "child_account": $child_account,
+              "branch": $branch,
+              "infra_live_repo": $infra_live_repo,
+              "working_directory": $working_directory,
+              "terragrunt_command": $terragrunt_command
+            }')" >> "$GITHUB_OUTPUT"
+          )"
+        elif [[ "$CHANGE_TYPE" == "TeamAccountsRequested" ]]; then
+          echo "workflow=create-sdlc-accounts-and-generate-baselines.yml" >> "$GITHUB_OUTPUT"
+          echo "workflow_inputs=$(jq -c -n \
+            --arg management_account "$MANAGEMENT_ACCOUNT" \
+            --arg branch "$BRANCH" \
+            --arg infra_live_repo "$INFRA_LIVE_REPO" \
+            --arg working_directory "$WORKING_DIRECTORY" \
+            --arg terragrunt_command "$COMMAND $ARGS" \
+            --arg team_account_names "$TEAM_ACCOUNT_NAMES" \
+            '{
+              "management_account": $management_account,
+              "branch": $branch,
+              "infra_live_repo": $infra_live_repo,
+              "working_directory": $working_directory,
+              "terragrunt_command": $terragrunt_command,
+              "team_account_names": $team_account_names
+            }')" >> "$GITHUB_OUTPUT"
+          )"
+        elif [[ "$CHANGE_TYPE" == "TeamAccountsAdded" ]]; then
+          echo "workflow=apply-new-sdlc-accounts-baseline.yml" >> "$GITHUB_OUTPUT"
+          echo "workflow_inputs=$(jq -c -n \
+            --arg management_account "$MANAGEMENT_ACCOUNT" \
+            --arg branch "$BRANCH" \
+            --arg infra_live_repo "$INFRA_LIVE_REPO" \
+            --arg working_directory "$WORKING_DIRECTORY" \
+            --arg terragrunt_command "$COMMAND $ARGS" \
+            --arg team_account_data "$TEAM_ACCOUNT_DATA" \
+            '{
+              "management_account": $management_account,
+              "branch": $branch,
+              "infra_live_repo": $infra_live_repo,
+              "working_directory": $working_directory,
+              "terragrunt_command": $terragrunt_command,
+              "team_account_data": $team_account_data
+            }')" >> "$GITHUB_OUTPUT"
+          )"
+        else
+          echo "workflow=terragrunt-executor.yml" >> "$GITHUB_OUTPUT"
+          echo "workflow_inputs=$(jq -c -n \
+            --arg account "$MANAGEMENT_ACCOUNT" \
+            --arg branch "$BRANCH" \
+            --arg infra_live_repo "$INFRA_LIVE_REPO" \
+            --arg working_directory "$WORKING_DIRECTORY" \
+            --arg terragrunt_command "$COMMAND $ARGS" \
+            '{
+              "account": $account,
+              "branch": $branch,
+              "infra_live_repo": $infra_live_repo,
+              "working_directory": $working_directory,
+              "terragrunt_command": $terragrunt_command
+            }')" >> "$GITHUB_OUTPUT"
+          )"
+        fi
+
     - name: Dispatch default workflow and get the run ID
-      if: ${{ !contains(fromJSON('["AccountRequested", "AccountAdded", "TeamAccountsRequested", "TeamAccountsAdded"]'), inputs.change_type)}}
       env:
         GH_TOKEN: ${{ inputs.infra_pipelines_token }}
       uses: codex-/return-dispatch@v1.10.0
@@ -72,100 +174,11 @@ runs:
         ref: "refs/heads/main"
         repo: ${{ inputs.repo }}
         owner: ${{ inputs.repo_owner }}
-        workflow: terragrunt-executor.yml
-        workflow_inputs: '{
-          "account": "${{ inputs.account_id }}",
-          "branch": "${{ inputs.branch }}",
-          "infra_live_repo": "${{ github.repository }}",
-          "working_directory": "${{ inputs.working_directory }}",
-          "terragrunt_command": "${{ inputs.command }} ${{ inputs.args }}",
-          "pipelines_change_type": "${{ inputs.change_type }}",
-          "child_account_id": "${{ fromJSON(inputs.additional_data).ChildAccountId }}"
-          }'
-    - name: Dispatch account-requested workflow and get the run ID
-      if: ${{ inputs.change_type == 'AccountRequested' }}
-      env:
-        GH_TOKEN: ${{ inputs.infra_pipelines_token }}
-      uses: codex-/return-dispatch@v1.10.0
-      id: return_dispatch_acct_req
-      with:
-        token: ${{ inputs.infra_pipelines_token }}
-        ref: "refs/heads/main"
-        repo: ${{ inputs.repo }}
-        owner: ${{ inputs.repo_owner }}
-        workflow: create-account-and-generate-baselines.yml
-        workflow_inputs: '{
-          "management_account": "${{ inputs.account_id }}",
-          "new_account_name": "${{ fromJSON(inputs.additional_data).AccountName }}",
-          "branch": "${{ inputs.branch }}",
-          "infra_live_repo": "${{ github.repository }}",
-          "working_directory": "${{ inputs.working_directory }}",
-          "terragrunt_command": "${{ inputs.command }} ${{ inputs.args }}"
-          }'
-    - name: Dispatch team-accounts-requested workflow and get the run ID
-      if: ${{ inputs.change_type == 'TeamAccountsRequested' }}
-      env:
-        GH_TOKEN: ${{ inputs.infra_pipelines_token }}
-      uses: codex-/return-dispatch@v1.10.0
-      id: return_dispatch_team_accts_req
-      with:
-        token: ${{ inputs.infra_pipelines_token }}
-        ref: "refs/heads/main"
-        repo: ${{ inputs.repo }}
-        owner: ${{ inputs.repo_owner }}
-        workflow: create-sdlc-accounts-and-generate-baselines.yml
-        workflow_inputs: '{
-          "management_account": "${{ inputs.account_id }}",
-          "branch": "${{ inputs.branch }}",
-          "infra_live_repo": "${{ github.repository }}",
-          "working_directory": "${{ inputs.working_directory }}",
-          "terragrunt_command": "${{ inputs.command }} ${{ inputs.args }}",
-          "team_account_names": "${{ fromJSON(inputs.additional_data).TeamAccountNames }}"
-          }'
-    - name: Dispatch account-added workflow and get the run ID
-      if: ${{ inputs.change_type == 'AccountAdded' }}
-      env:
-        GH_TOKEN: ${{ inputs.infra_pipelines_token }}
-      uses: codex-/return-dispatch@v1.10.0
-      id: return_dispatch_acct_add
-      with:
-        token: ${{ inputs.infra_pipelines_token }}
-        ref: "refs/heads/main"
-        repo: ${{ inputs.repo }}
-        owner: ${{ inputs.repo_owner }}
-        workflow: apply-new-account-baseline.yml
-        workflow_inputs: '{
-          "management_account": "${{ inputs.account_id }}",
-          "child_account": "${{ fromJSON(inputs.additional_data).ChildAccountId }}",
-          "branch": "${{ inputs.branch }}",
-          "infra_live_repo": "${{ github.repository }}",
-          "working_directory": "${{ inputs.working_directory }}",
-          "terragrunt_command": "${{ inputs.command }} ${{ inputs.args }}"
-          }'
-    - name: Dispatch team-accounts-added workflow and get the run ID
-      if: ${{ inputs.change_type == 'TeamAccountsAdded' }}
-      env:
-        GH_TOKEN: ${{ inputs.infra_pipelines_token }}
-      uses: codex-/return-dispatch@v1.10.0
-      id: return_dispatch_team_accts_add
-      with:
-        token: ${{ inputs.infra_pipelines_token }}
-        ref: "refs/heads/main"
-        repo: ${{ inputs.repo }}
-        owner: ${{ inputs.repo_owner }}
-        workflow: apply-new-sdlc-accounts-baseline.yml
-        workflow_inputs: '{
-          "management_account": "${{ inputs.account_id }}",
-          "branch": "${{ inputs.branch }}",
-          "infra_live_repo": "${{ github.repository }}",
-          "working_directory": "${{ inputs.working_directory }}",
-          "terragrunt_command": "${{ inputs.command }} ${{ inputs.args }}",
-          "team_account_data": ${{ toJSON(inputs.additional_data) }}
-          }'
+        workflow: ${{ steps.setup-action-configurations.outputs.workflow }}
+        workflow_inputs: ${{ steps.setup-action-configurations.outputs.workflow_inputs }}
 
     # Await default workflow run
     - name: Await Run ID ${{ steps.return_dispatch.outputs.run_id }}
-      if: ${{ !contains(fromJSON('["AccountRequested", "AccountAdded", "TeamAccountsRequested", "TeamAccountsAdded"]'), inputs.change_type)}}
       env:
         GH_TOKEN: ${{ inputs.infra_pipelines_token }}
       uses: Codex-/await-remote-run@v1.9.0
@@ -178,7 +191,7 @@ runs:
         poll_interval_ms: 5000 # Optional
 
     - name: Completed
-      if: ${{ always() && !contains(fromJSON('["AccountRequested", "AccountAdded", "TeamAccountsRequested", "TeamAccountsAdded"]'), inputs.change_type)}}
+      if: ${{ always() }}
       shell: bash
       env:
         COMMAND: ${{ inputs.command }}
@@ -187,94 +200,6 @@ runs:
         REPO: ${{ inputs.repo }}
         REPO_OWNER: ${{ inputs.repo_owner }}
       run: echo "::notice ::Completed $COMMAND for $WORKING_DIR in acct $ACC0UNT_ID%0AFor details see https://github.com/$REPO_OWNER/$REPO/actions/runs/${{ steps.return_dispatch.outputs.run_id }}"
-
-    # Await account-requested workflow run
-    - name: Await Acct Req Run ID ${{ steps.return_dispatch_acct_req.outputs.run_id }}
-      if: ${{ always() && inputs.change_type == 'AccountRequested' }}
-      env:
-        GH_TOKEN: ${{ inputs.infra_pipelines_token }}
-      uses: Codex-/await-remote-run@v1.9.0
-      with:
-        token: ${{ inputs.infra_pipelines_token }}
-        repo: ${{ inputs.repo }}
-        owner: ${{ inputs.repo_owner }}
-        run_id: ${{ steps.return_dispatch_acct_req.outputs.run_id }}
-        run_timeout_seconds: 3600 # one hour
-        poll_interval_ms: 5000 # Optional
-
-    - name: Completed Acct Req
-      if: ${{ always() && inputs.change_type == 'AccountRequested' }}
-      shell: bash
-      env:
-        COMMAND: ${{ inputs.command }}
-        WORKING_DIR: ${{ inputs.working_directory }}
-        ACCOUNT_ID: ${{ inputs.account_id }}
-        REPO: ${{ inputs.repo }}
-        REPO_OWNER: ${{ inputs.repo_owner }}
-      run: echo "::notice ::Completed $COMMAND for $WORKING_DIR in acct $ACCOUNT_ID%0AFor details see https://github.com/$REPO_OWNER/$REPO/actions/runs/${{ steps.return_dispatch_acct_req.outputs.run_id }}"
-
-    # Await team-accounts-requested workflow run
-    - name: Await Acct Req Run ID ${{ steps.return_dispatch_team_accts_req.outputs.run_id }}
-      if: ${{ always() && inputs.change_type == 'TeamAccountsRequested' }}
-      env:
-        GH_TOKEN: ${{ inputs.infra_pipelines_token }}
-      uses: Codex-/await-remote-run@v1.9.0
-      with:
-        token: ${{ inputs.infra_pipelines_token }}
-        repo: ${{ inputs.repo }}
-        owner: ${{ inputs.repo_owner }}
-        run_id: ${{ steps.return_dispatch_team_accts_req.outputs.run_id }}
-        run_timeout_seconds: 3600 # one hour
-        poll_interval_ms: 5000 # Optional
-
-    - name: Completed Team Accounts Requested workflow
-      if: ${{ always() && inputs.change_type == 'TeamAccountsRequested' }}
-      shell: bash
-      env:
-        COMMAND: ${{ inputs.command }}
-        WORKING_DIR: ${{ inputs.working_directory }}
-        ACCOUNT_ID: ${{ inputs.account_id }}
-        REPO: ${{ inputs.repo }}
-        REPO_OWNER: ${{ inputs.repo_owner }}
-      run: echo "::notice ::Completed $COMMAND for $WORKING_DIR in acct $ACCOUNT_ID%0AFor details see https://github.com/$REPO_OWNER/$REPO/actions/runs/${{ steps.return_dispatch_team_accts_req.outputs.run_id }}"
-
-    # Await account-added workflow run
-    - name: Await Acct Add Run ID ${{ steps.return_dispatch_acct_add.outputs.run_id }}
-      if: ${{ always() && inputs.change_type == 'AccountAdded' }}
-      env:
-        GH_TOKEN: ${{ inputs.infra_pipelines_token }}
-      uses: Codex-/await-remote-run@v1.9.0
-      with:
-        token: ${{ inputs.infra_pipelines_token }}
-        repo: ${{ inputs.repo }}
-        owner: ${{ inputs.repo_owner }}
-        run_id: ${{ steps.return_dispatch_acct_add.outputs.run_id }}
-        run_timeout_seconds: 3600 # one hour
-        poll_interval_ms: 5000 # Optional
-
-    - name: Completed Acct Add
-      if: ${{ always() && inputs.change_type == 'AccountAdded' }}
-      shell: bash
-      run: echo "::notice ::Completed ${{ inputs.command }} for ${{ inputs.working_directory }} in acct ${{ inputs.account_id }}%0AFor details see https://github.com/${{ inputs.repo_owner }}/${{ inputs.repo }}/actions/runs/${{ steps.return_dispatch_acct_add.outputs.run_id }}"
-
-    # Await team-accounts-added workflow run
-    - name: Await Acct Add Run ID ${{ steps.return_dispatch_team_accts_add.outputs.run_id }}
-      if: ${{ always() && inputs.change_type == 'TeamAccountsAdded' }}
-      env:
-        GH_TOKEN: ${{ inputs.infra_pipelines_token }}
-      uses: Codex-/await-remote-run@v1.9.0
-      with:
-        token: ${{ inputs.infra_pipelines_token }}
-        repo: ${{ inputs.repo }}
-        owner: ${{ inputs.repo_owner }}
-        run_id: ${{ steps.return_dispatch_team_accts_add.outputs.run_id }}
-        run_timeout_seconds: 3600 # one hour
-        poll_interval_ms: 5000 # Optional
-
-    - name: Completed Team Accounts Added workflow
-      if: ${{ always() && inputs.change_type == 'TeamAccountsAdded' }}
-      shell: bash
-      run: echo "::notice ::Completed ${{ inputs.command }} for ${{ inputs.working_directory }} in acct ${{ inputs.account_id }}%0AFor details see https://github.com/${{ inputs.repo_owner }}/${{ inputs.repo }}/actions/runs/${{ steps.return_dispatch_team_accts_add.outputs.run_id }}"
 
     - name: Get Job ID & Terragrunt Run URL
       if: ${{ always() }} # This ensures this step always runs regardless of failure of previous step
@@ -339,11 +264,8 @@ runs:
         if [ $TERRAGRUNT_STEP_STATUS = 'succeeded' ]; then
           COPY="_To **apply** all changes, merge this pull request._"$'\n'"_On merge, another comment will be added to this pull request with apply logs._"
         else
-          COPY="_To **re-run** the plan, push a new set of changes to this pull request’s branch._"
+          COPY="_To **re-run** the plan, push a new set of changes to this pull request's branch._"
         fi
-
-        # TODO: Remove debug echo
-        echo "COPY=$COPY"
 
         # Post PR comment indicating terragrunt plan success/failure
         COMMENT_BODY=$'## Terragrunt Plan\n\n'"$TERRAGRUNT_STEP_EMOJI Terragrunt Plan $TERRAGRUNT_STEP_STATUS for "$'`'"$WORKING_DIR"$'`.\n\n '"$COPY"$'\n\n[View logs]('"$TERRAGRUNT_STEP_URL"$')'
@@ -399,9 +321,6 @@ runs:
         else
           COPY="_To recover from the failure, check the logs, push any required changes to a new branch, then create a new pull request._"
         fi
-
-        # TODO: Remove debug echo
-        echo "COPY=$COPY"
 
         # Post PR comment indicating terragrunt apply success/failure
         COMMENT_BODY=$'## Terragrunt Apply\n\n'"$TERRAGRUNT_STEP_EMOJI Terragrunt Apply $TERRAGRUNT_STEP_STATUS for "$'`'"$WORKING_DIR"$'`.\n\n '"$COPY"$'\n\n[View logs]('"$TERRAGRUNT_STEP_URL"$')'

--- a/action.yml
+++ b/action.yml
@@ -90,8 +90,8 @@ runs:
               "infra_live_repo": $infra_live_repo,
               "working_directory": $working_directory,
               "terragrunt_command": $terragrunt_command
-            }')" >> "$GITHUB_OUTPUT"
-          )"
+            }'
+          )" >> "$GITHUB_OUTPUT"
         elif [[ "$CHANGE_TYPE" == "AccountAdded" ]]; then
           echo "workflow=apply-new-account-baseline.yml" >> "$GITHUB_OUTPUT"
           echo "workflow_inputs=$(jq -c -n \
@@ -108,8 +108,8 @@ runs:
               "infra_live_repo": $infra_live_repo,
               "working_directory": $working_directory,
               "terragrunt_command": $terragrunt_command
-            }')" >> "$GITHUB_OUTPUT"
-          )"
+            }'
+          )" >> "$GITHUB_OUTPUT"
         elif [[ "$CHANGE_TYPE" == "TeamAccountsRequested" ]]; then
           echo "workflow=create-sdlc-accounts-and-generate-baselines.yml" >> "$GITHUB_OUTPUT"
           echo "workflow_inputs=$(jq -c -n \
@@ -126,8 +126,8 @@ runs:
               "working_directory": $working_directory,
               "terragrunt_command": $terragrunt_command,
               "team_account_names": $team_account_names
-            }')" >> "$GITHUB_OUTPUT"
-          )"
+            }'
+          )" >> "$GITHUB_OUTPUT"
         elif [[ "$CHANGE_TYPE" == "TeamAccountsAdded" ]]; then
           echo "workflow=apply-new-sdlc-accounts-baseline.yml" >> "$GITHUB_OUTPUT"
           echo "workflow_inputs=$(jq -c -n \
@@ -144,8 +144,8 @@ runs:
               "working_directory": $working_directory,
               "terragrunt_command": $terragrunt_command,
               "team_account_data": $team_account_data
-            }')" >> "$GITHUB_OUTPUT"
-          )"
+            }'
+          )" >> "$GITHUB_OUTPUT"
         else
           echo "workflow=terragrunt-executor.yml" >> "$GITHUB_OUTPUT"
           echo "workflow_inputs=$(jq -c -n \
@@ -160,8 +160,8 @@ runs:
               "infra_live_repo": $infra_live_repo,
               "working_directory": $working_directory,
               "terragrunt_command": $terragrunt_command
-            }')" >> "$GITHUB_OUTPUT"
-          )"
+            }'
+          )" >> "$GITHUB_OUTPUT"
         fi
 
     - name: Dispatch default workflow and get the run ID

--- a/action.yml
+++ b/action.yml
@@ -36,6 +36,7 @@ inputs:
       - ModuleChanged
       - ModuleDeleted
       - ModuleAdded
+      - ModulesAdded
       - EnvCommonChanged
       - EnvCommonDeleted
       - EnvCommonAdded


### PR DESCRIPTION
## Summary

This makes it so that we're doing one step at the top to setup the logic that we need lower down, then doing one set of steps to execute the dispatch and waits

## Changes

- Merging main back into this branch
- Moving to configuring action in step instead of repeating logic

## Comments

I think these long-lived branches like `team-accounts` are really dangerous. We should merge into `main` more frequently if we can to avoid mega-merges. Folks should be using pinned tags for their actions anyways, so any instability incurred by merging to `main` can be mitigated by pinning back to a previous version.

