### PR TITLE
Adding `pipelines auth presign` usage.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ This GitHub Action, named "Pipelines Dispatch," is designed to dispatch Terragru
 - `change_type` (required): The type of infrastructure change that occurred.
 - `additional_data` (optional): Additional data related to the change type.
 - `actor` (required): The GitHub actor responsible for the change.
+- `pipelines_token` (optional): GitHub PAT to download `pipelines` binary. If not provided, the action will not install the binary.
+- `pipelines_cli_version` (optional): The version of the `pipelines` binary to download. If not provided, a default version will be used.
+- `pipelines_auth_role` (optional): The IAM role to assume when running the `pipelines auth presign`. If not provided, the action will not assume a role or perform the presign operation.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ This GitHub Action, named "Pipelines Dispatch," is designed to dispatch Terragru
 - `pipelines_token` (optional): GitHub PAT to download `pipelines` binary. If not provided, the action will not install the binary.
 - `pipelines_cli_version` (optional): The version of the `pipelines` binary to download. If not provided, a default version will be used.
 - `pipelines_auth_role` (optional): The IAM role to assume when running the `pipelines auth presign`. If not provided, the action will not assume a role or perform the presign operation.
+- `pipelines_auth_region` (optional): The AWS region in which to perform the `pipelines auth presign`. If not provided, the `us-east-1` region will be used.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@ This GitHub Action, named "Pipelines Dispatch," is designed to dispatch Terragru
 - `change_type` (required): The type of infrastructure change that occurred.
 - `additional_data` (optional): Additional data related to the change type.
 - `actor` (required): The GitHub actor responsible for the change.
+
+### Pipelines Presign Inputs
+
+If these inputs are provided, the action will download the `pipelines` binary and run `pipelines auth presign` to generate a presigned `GetCallerIdentity` request for the specified role and region. The presigned request will be passed to the `infrastructure-pipelines` workflow as an additional input. This is a useful, additional layer of security to ensure that the `infrastructure-pipelines` workflow is being called by a repo it trusts.
+
 - `pipelines_token` (optional): GitHub PAT to download `pipelines` binary. If not provided, the action will not install the binary.
 - `pipelines_cli_version` (optional): The version of the `pipelines` binary to download. If not provided, a default version will be used.
 - `pipelines_auth_role` (optional): The IAM role to assume when running the `pipelines auth presign`. If not provided, the action will not assume a role or perform the presign operation.

--- a/action.yml
+++ b/action.yml
@@ -63,7 +63,7 @@ inputs:
   pipelines_cli_version:
     description: "The version of the Gruntwork Pipelines CLI to use"
     required: false
-    default: "0.3.0"
+    default: "0.4.0"
   pipelines_auth_role:
     description: "The role to assume before running `pipelines auth presign`, which is used to authenticate the calling repo. Only necessary when pipelines auth role is provisioned and checked in infrastructure-pipelines repo."
     required: false

--- a/action.yml
+++ b/action.yml
@@ -57,10 +57,48 @@ inputs:
   actor:
     description: "The github actor responsible for the change"
     required: true
+  pipelines_token:
+    description: "The GitHub token for downloading the Gruntwork Pipelines binary"
+    required: false
+  pipelines_cli_version:
+    description: "The version of the Gruntwork Pipelines CLI to use"
+    required: false
+    default: "0.3.0"
+  pipelines_auth_role:
+    description: "The role to assume before running `pipelines auth presign`, which is used to authenticate the calling repo. Only necessary when pipelines auth role is provisioned and checked in infrastructure-pipelines repo."
+    required: false
+  pipelines_auth_region:
+    description: "The region in which the role to assume before running `pipelines auth presign`. Only necessary when pipelines auth role is provisioned and checked in infrastructure-pipelines repo."
+    required: false
+    default: "us-east-1"
 
 runs:
   using: "composite"
   steps:
+    - name: Download Pipelines CLI
+      if: ${{ inputs.pipelines_token != '' }}
+      uses: dsaltares/fetch-gh-release-asset@1.1.1
+      with:
+        repo: "gruntwork-io/pipelines-cli"
+        version: "tags/${{ inputs.pipelines_cli_version }}"
+        file: "pipelines_linux_amd64"
+        target: "/tmp/pipelines"
+        token: ${{ inputs.token }}
+
+    - name: Install Pipelines CLI
+      if: ${{ inputs.pipelines_token != '' }}
+      shell: bash
+      run: |
+        sudo mv /tmp/pipelines /usr/local/bin/pipelines
+        sudo chmod +x /usr/local/bin/pipelines
+
+    - name: Authenticate with AWS
+      if: ${{ inputs.pipelines_auth_role != '' }}
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        role-to-assume: arn:aws:iam::${{ inputs.account_id }}:role/${{ inputs.pipelines_auth_role }}
+        aws-region: ${{ inputs.pipelines_auth_region }}
+
     - name: Setup Action Configurations
       id: setup-action-configurations
       shell: bash
@@ -74,100 +112,8 @@ runs:
         COMMAND: ${{ inputs.command }}
         ARGS: ${{ inputs.args }}
         CHILD_ACCOUNT_ID: ${{ fromJSON(inputs.additional_data).ChildAccountId }}
-      run: |
-        if [[ "$CHANGE_TYPE" == "AccountRequested" ]]; then
-          echo "workflow=create-account-and-generate-baselines.yml" >> "$GITHUB_OUTPUT"
-          echo "workflow_inputs=$(jq -c -n \
-            --arg management_account "$MANAGEMENT_ACCOUNT" \
-            --arg new_account_name "$NEW_ACCOUNT_NAME" \
-            --arg branch "$BRANCH" \
-            --arg infra_live_repo "$INFRA_LIVE_REPO" \
-            --arg working_directory "$WORKING_DIRECTORY" \
-            --arg terragrunt_command "$COMMAND $ARGS" \
-            '{
-              "management_account": $management_account,
-              "new_account_name": $new_account_name,
-              "branch": $branch,
-              "infra_live_repo": $infra_live_repo,
-              "working_directory": $working_directory,
-              "terragrunt_command": $terragrunt_command
-            }'
-          )" >> "$GITHUB_OUTPUT"
-        elif [[ "$CHANGE_TYPE" == "AccountAdded" ]]; then
-          echo "workflow=apply-new-account-baseline.yml" >> "$GITHUB_OUTPUT"
-          echo "workflow_inputs=$(jq -c -n \
-            --arg management_account "$MANAGEMENT_ACCOUNT" \
-            --arg child_account "$NEW_ACCOUNT_NAME" \
-            --arg branch "$BRANCH" \
-            --arg infra_live_repo "$INFRA_LIVE_REPO" \
-            --arg working_directory "$WORKING_DIRECTORY" \
-            --arg terragrunt_command "$COMMAND $ARGS" \
-            '{
-              "management_account": $management_account,
-              "child_account": $child_account,
-              "branch": $branch,
-              "infra_live_repo": $infra_live_repo,
-              "working_directory": $working_directory,
-              "terragrunt_command": $terragrunt_command
-            }'
-          )" >> "$GITHUB_OUTPUT"
-        elif [[ "$CHANGE_TYPE" == "TeamAccountsRequested" ]]; then
-          echo "workflow=create-sdlc-accounts-and-generate-baselines.yml" >> "$GITHUB_OUTPUT"
-          echo "workflow_inputs=$(jq -c -n \
-            --arg management_account "$MANAGEMENT_ACCOUNT" \
-            --arg branch "$BRANCH" \
-            --arg infra_live_repo "$INFRA_LIVE_REPO" \
-            --arg working_directory "$WORKING_DIRECTORY" \
-            --arg terragrunt_command "$COMMAND $ARGS" \
-            --arg team_account_names "$TEAM_ACCOUNT_NAMES" \
-            '{
-              "management_account": $management_account,
-              "branch": $branch,
-              "infra_live_repo": $infra_live_repo,
-              "working_directory": $working_directory,
-              "terragrunt_command": $terragrunt_command,
-              "team_account_names": $team_account_names
-            }'
-          )" >> "$GITHUB_OUTPUT"
-        elif [[ "$CHANGE_TYPE" == "TeamAccountsAdded" ]]; then
-          echo "workflow=apply-new-sdlc-accounts-baseline.yml" >> "$GITHUB_OUTPUT"
-          echo "workflow_inputs=$(jq -c -n \
-            --arg management_account "$MANAGEMENT_ACCOUNT" \
-            --arg branch "$BRANCH" \
-            --arg infra_live_repo "$INFRA_LIVE_REPO" \
-            --arg working_directory "$WORKING_DIRECTORY" \
-            --arg terragrunt_command "$COMMAND $ARGS" \
-            --arg team_account_data "$TEAM_ACCOUNT_DATA" \
-            '{
-              "management_account": $management_account,
-              "branch": $branch,
-              "infra_live_repo": $infra_live_repo,
-              "working_directory": $working_directory,
-              "terragrunt_command": $terragrunt_command,
-              "team_account_data": $team_account_data
-            }'
-          )" >> "$GITHUB_OUTPUT"
-        else
-          echo "workflow=terragrunt-executor.yml" >> "$GITHUB_OUTPUT"
-          echo "workflow_inputs=$(jq -c -n \
-            --arg account "$MANAGEMENT_ACCOUNT" \
-            --arg branch "$BRANCH" \
-            --arg infra_live_repo "$INFRA_LIVE_REPO" \
-            --arg working_directory "$WORKING_DIRECTORY" \
-            --arg terragrunt_command "$COMMAND $ARGS" \
-            --arg pipelines_change_type "$CHANGE_TYPE" \
-            --arg child_account_id "$CHILD_ACCOUNT_ID" \
-            '{
-              "account": $account,
-              "branch": $branch,
-              "infra_live_repo": $infra_live_repo,
-              "working_directory": $working_directory,
-              "terragrunt_command": $terragrunt_command,
-              "pipelines_change_type": $pipelines_change_type,
-              "child_account_id": $child_account_id
-            }'
-          )" >> "$GITHUB_OUTPUT"
-        fi
+        PIPELINES_AUTH_ROLE: ${{ inputs.pipelines_auth_role }}
+      run: ./scripts/setup-action-configurations.sh
 
     - name: Dispatch default workflow and get the run ID
       env:

--- a/action.yml
+++ b/action.yml
@@ -115,7 +115,7 @@ runs:
         PIPELINES_AUTH_ROLE: ${{ inputs.pipelines_auth_role }}
         TEAM_ACCOUNT_NAMES: "${{ toJSON(fromJSON(inputs.additional_data).TeamAccountNames) }}"
         TEAM_ACCOUNT_DATA: ${{ inputs.additional_data }}
-      run: ./scripts/setup-action-configurations.sh
+      run: ./scripts/setup-action-configs.sh
 
     - name: Dispatch default workflow and get the run ID
       env:

--- a/scripts/setup-action-configs.sh
+++ b/scripts/setup-action-configs.sh
@@ -31,6 +31,13 @@ presign_caller_identity_token() {
     pipelines auth presign
 }
 
+append_presigned_caller_identity_token() {
+    readonly workflow_inputs="$1"
+
+    presigned_caller_identity="$(presign_caller_identity_token)"
+    jq --arg presigned_caller_identity "$presigned_caller_identity" '. + {presigned_caller_identity: $presigned_caller_identity}' <<< "$workflow_inputs"
+}
+
 handle_account_request() {
     readonly management_account="$1"
     readonly new_account_name="$2"
@@ -58,8 +65,7 @@ handle_account_request() {
         }'
     )"
     if [[ -n "$pipelines_auth_role" ]]; then
-        presigned_caller_identity="$(presign_caller_identity_token)"
-        workflow_inputs="$(jq --arg presigned_caller_identity "$presigned_caller_identity" '. + {presigned_caller_identity: $presigned_caller_identity}' <<< "$workflow_inputs")"
+        workflow_inputs="$(append_presigned_caller_identity_token "$workflow_inputs")"
     fi
     echo "workflow_inputs=$workflow_inputs" >> "$GITHUB_OUTPUT"
 }
@@ -91,8 +97,7 @@ handle_account_added() {
         }'
     )"
     if [[ -n "$pipelines_auth_role" ]]; then
-        presigned_caller_identity="$(presign_caller_identity_token)"
-        workflow_inputs="$(jq --arg presigned_caller_identity "$presigned_caller_identity" '. + {presigned_caller_identity: $presigned_caller_identity}' <<< "$workflow_inputs")"
+        workflow_inputs="$(append_presigned_caller_identity_token "$workflow_inputs")"
     fi
     echo "workflow_inputs=$workflow_inputs" >> "$GITHUB_OUTPUT"
 }
@@ -122,8 +127,7 @@ handle_team_accounts_requested() {
         }'
     )"
     if [[ -n "$pipelines_auth_role" ]]; then
-        presigned_caller_identity="$(presign_caller_identity_token)"
-        workflow_inputs="$(jq --arg presigned_caller_identity "$presigned_caller_identity" '. + {presigned_caller_identity: $presigned_caller_identity}' <<< "$workflow_inputs")"
+        workflow_inputs="$(append_presigned_caller_identity_token "$workflow_inputs")"
     fi
     echo "workflow_inputs=$workflow_inputs" >> "$GITHUB_OUTPUT"
 }
@@ -155,8 +159,7 @@ handle_team_accounts_added() {
         }'
     )
     if [[ -n "$pipelines_auth_role" ]]; then
-        presigned_caller_identity="$(presign_caller_identity_token)"
-        workflow_inputs="$(jq --arg presigned_caller_identity "$presigned_caller_identity" '. + {presigned_caller_identity: $presigned_caller_identity}' <<< "$workflow_inputs")"
+        workflow_inputs="$(append_presigned_caller_identity_token "$workflow_inputs")"
     fi
     echo "workflow_inputs=$workflow_inputs" >> "$GITHUB_OUTPUT"
 }
@@ -190,8 +193,7 @@ handle_default() {
         }'
     )
     if [[ -n "$pipelines_auth_role" ]]; then
-        presigned_caller_identity="$(presign_caller_identity_token)"
-        workflow_inputs="$(jq --arg presigned_caller_identity "$presigned_caller_identity" '. + {presigned_caller_identity: $presigned_caller_identity}' <<< "$workflow_inputs")"
+        workflow_inputs="$(append_presigned_caller_identity_token "$workflow_inputs")"
     fi
     echo "workflow_inputs=$workflow_inputs" >> "$GITHUB_OUTPUT"
 }

--- a/scripts/setup-action-configs.sh
+++ b/scripts/setup-action-configs.sh
@@ -1,0 +1,215 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+IFS=$'\n\t'
+
+# Required environment variables
+: "${CHANGE_TYPE:? "CHANGE_TYPE environment variable must be set"}"
+: "${MANAGEMENT_ACCOUNT:? "MANAGEMENT_ACCOUNT environment variable must be set"}"
+: "${BRANCH:? "BRANCH environment variable must be set"}"
+: "${INFRA_LIVE_REPO:? "INFRA_LIVE_REPO environment variable must be set"}"
+: "${WORKING_DIRECTORY:? "WORKING_DIRECTORY environment variable must be set"}"
+: "${COMMAND:? "COMMAND environment variable must be set"}"
+: "${ARGS:? "ARGS environment variable must be set"}"
+
+# Optional environment variables
+NEW_ACCOUNT_NAME="${NEW_ACCOUNT_NAME:-}"
+TEAM_ACCOUNT_NAMES="${TEAM_ACCOUNT_NAMES:-}"
+CHILD_ACCOUNT_ID="${CHILD_ACCOUNT_ID:-}"
+PIPELINES_AUTH_ROLE="${PIPELINES_AUTH_ROLE:-}"
+
+check_pipeline_is_installed() {
+    if ! command -v pipelines &> /dev/null; then
+        echo "pipelines CLI not installed"
+        exit 1
+    fi
+}
+
+presign_caller_identity_token() {
+    check_pipeline_is_installed
+
+    pipelines auth presign
+}
+
+handle_account_request() {
+    readonly management_account="$1"
+    readonly new_account_name="$2"
+    readonly branch="$3"
+    readonly infra_live_repo="$4"
+    readonly working_directory="$5"
+    readonly terragrunt_command="$6"
+    readonly pipelines_auth_role="$7"
+
+    echo "workflow=create-account-and-generate-baselines.yml" >> "$GITHUB_OUTPUT"
+    workflow_inputs="$(jq -c -n \
+        --arg management_account "$management_account" \
+        --arg new_account_name "$new_account_name" \
+        --arg branch "$branch" \
+        --arg infra_live_repo "$infra_live_repo" \
+        --arg working_directory "$working_directory" \
+        --arg terragrunt_command "$terragrunt_command" \
+        '{
+            "management_account": $management_account,
+            "new_account_name": $new_account_name,
+            "branch": $branch,
+            "infra_live_repo": $infra_live_repo,
+            "working_directory": $working_directory,
+            "terragrunt_command": $terragrunt_command
+        }'
+    )"
+    if [[ -n "$pipelines_auth_role" ]]; then
+        presigned_caller_identity="$(presign_caller_identity_token)"
+        workflow_inputs="$(jq --arg presigned_caller_identity "$presigned_caller_identity" '. + {presigned_caller_identity: $presigned_caller_identity}' <<< "$workflow_inputs")"
+    fi
+    echo "workflow_inputs=$workflow_inputs" >> "$GITHUB_OUTPUT"
+}
+
+handle_account_added() {
+    readonly management_account="$1"
+    readonly new_account_name="$2"
+    readonly branch="$3"
+    readonly infra_live_repo="$4"
+    readonly working_directory="$5"
+    readonly terragrunt_command="$6"
+    readonly pipelines_auth_role="$7"
+
+    echo "workflow=apply-new-account-baseline.yml" >> "$GITHUB_OUTPUT"
+    workflow_inputs="$(jq -c -n \
+        --arg management_account "$management_account" \
+        --arg new_account_name "$new_account_name" \
+        --arg branch "$branch" \
+        --arg infra_live_repo "$infra_live_repo" \
+        --arg working_directory "$working_directory" \
+        --arg terragrunt_command "$terragrunt_command" \
+        '{
+            "management_account": $management_account,
+            "new_account_name": $new_account_name,
+            "branch": $branch,
+            "infra_live_repo": $infra_live_repo,
+            "working_directory": $working_directory,
+            "terragrunt_command": $terragrunt_command
+        }'
+    )"
+    if [[ -n "$pipelines_auth_role" ]]; then
+        presigned_caller_identity="$(presign_caller_identity_token)"
+        workflow_inputs="$(jq --arg presigned_caller_identity "$presigned_caller_identity" '. + {presigned_caller_identity: $presigned_caller_identity}' <<< "$workflow_inputs")"
+    fi
+    echo "workflow_inputs=$workflow_inputs" >> "$GITHUB_OUTPUT"
+}
+
+handle_team_accounts_requested() {
+    readonly management_account="$1"
+    readonly branch="$2"
+    readonly infra_live_repo="$3"
+    readonly working_directory="$4"
+    readonly terragrunt_command="$5"
+    readonly team_account_names="$6"
+    readonly pipelines_auth_role="$7"
+
+    echo "workflow=create-sdlc-accounts-and-generate-baselines.yml" >> "$GITHUB_OUTPUT"
+    workflow_inputs="$(jq -c -n \
+        --arg management_account "$management_account" \
+        --arg branch "$branch" \
+        --arg infra_live_repo "$infra_live_repo" \
+        --arg working_directory "$working_directory" \
+        --arg terragrunt_command "$terragrunt_command" \
+        '{
+            "management_account": $management_account,
+            "branch": $branch,
+            "infra_live_repo": $infra_live_repo,
+            "working_directory": $working_directory,
+            "terragrunt_command": $terragrunt_command
+        }'
+    )"
+    if [[ -n "$pipelines_auth_role" ]]; then
+        presigned_caller_identity="$(presign_caller_identity_token)"
+        workflow_inputs="$(jq --arg presigned_caller_identity "$presigned_caller_identity" '. + {presigned_caller_identity: $presigned_caller_identity}' <<< "$workflow_inputs")"
+    fi
+    echo "workflow_inputs=$workflow_inputs" >> "$GITHUB_OUTPUT"
+}
+
+handle_team_accounts_added() {
+    readonly management_account="$1"
+    readonly branch="$2"
+    readonly infra_live_repo="$3"
+    readonly working_directory="$4"
+    readonly terragrunt_command="$5"
+    readonly team_account_names="$6"
+    readonly pipelines_auth_role="$7"
+
+    echo "workflow=apply-new-sdlc-accounts-baseline.yml" >> "$GITHUB_OUTPUT"
+    workflow_inputs=$(jq -c -n \
+        --arg management_account "$management_account" \
+        --arg branch "$branch" \
+        --arg infra_live_repo "$infra_live_repo" \
+        --arg working_directory "$working_directory" \
+        --arg terragrunt_command "$terragrunt_command" \
+        --arg team_account_names "$team_account_names" \
+        '{
+            "management_account": $management_account,
+            "branch": $branch,
+            "infra_live_repo": $infra_live_repo,
+            "working_directory": $working_directory,
+            "terragrunt_command": $terragrunt_command,
+            "team_account_names": $team_account_names
+        }'
+    )
+    if [[ -n "$pipelines_auth_role" ]]; then
+        presigned_caller_identity="$(presign_caller_identity_token)"
+        workflow_inputs="$(jq --arg presigned_caller_identity "$presigned_caller_identity" '. + {presigned_caller_identity: $presigned_caller_identity}' <<< "$workflow_inputs")"
+    fi
+    echo "workflow_inputs=$workflow_inputs" >> "$GITHUB_OUTPUT"
+}
+
+handle_default() {
+    readonly management_account="$1"
+    readonly branch="$2"
+    readonly infra_live_repo="$3"
+    readonly working_directory="$4"
+    readonly terragrunt_command="$5"
+    readonly pipelines_change_type="$6"
+    readonly child_account_id="$7"
+
+    echo "workflow=terragrunt-executor.yml" >> "$GITHUB_OUTPUT"
+    workflow_inputs=$(jq -c -n \
+        --arg account "$management_account" \
+        --arg branch "$branch" \
+        --arg infra_live_repo "$infra_live_repo" \
+        --arg working_directory "$working_directory" \
+        --arg terragrunt_command "$terragrunt_command" \
+        --arg pipelines_change_type "$pipelines_change_type" \
+        --arg child_account_id "$child_account_id" \
+        '{
+            "account": $account,
+            "branch": $branch,
+            "infra_live_repo": $infra_live_repo,
+            "working_directory": $working_directory,
+            "terragrunt_command": $terragrunt_command,
+            "pipelines_change_type": $pipelines_change_type,
+            "child_account_id": $child_account_id
+        }'
+    )
+    if [[ -n "$pipelines_auth_role" ]]; then
+        presigned_caller_identity="$(presign_caller_identity_token)"
+        workflow_inputs="$(jq --arg presigned_caller_identity "$presigned_caller_identity" '. + {presigned_caller_identity: $presigned_caller_identity}' <<< "$workflow_inputs")"
+    fi
+    echo "workflow_inputs=$workflow_inputs" >> "$GITHUB_OUTPUT"
+}
+
+case "$CHANGE_TYPE" in
+    AccountRequested)
+        handle_account_request "$MANAGEMENT_ACCOUNT" "$NEW_ACCOUNT_NAME" "$BRANCH" "$INFRA_LIVE_REPO" "$WORKING_DIRECTORY" "$COMMAND $ARGS" "$PIPELINES_AUTH_ROLE"
+        ;;
+    AccountAdded)
+        handle_account_added "$MANAGEMENT_ACCOUNT" "$NEW_ACCOUNT_NAME" "$BRANCH" "$INFRA_LIVE_REPO" "$WORKING_DIRECTORY" "$COMMAND $ARGS" "$PIPELINES_AUTH_ROLE"
+        ;;
+    TeamAccountsRequested)
+        handle_team_accounts_requested "$MANAGEMENT_ACCOUNT" "$BRANCH" "$INFRA_LIVE_REPO" "$WORKING_DIRECTORY" "$COMMAND $ARGS" "$TEAM_ACCOUNT_NAMES" "$PIPELINES_AUTH_ROLE"
+        ;;
+    TeamAccountsAdded)
+        handle_team_accounts_added "$MANAGEMENT_ACCOUNT" "$BRANCH" "$INFRA_LIVE_REPO" "$WORKING_DIRECTORY" "$COMMAND $ARGS" "$TEAM_ACCOUNT_NAMES" "$PIPELINES_AUTH_ROLE"
+        ;;
+    *)
+        handle_default "$MANAGEMENT_ACCOUNT" "$BRANCH" "$INFRA_LIVE_REPO" "$WORKING_DIRECTORY" "$COMMAND $ARGS" "$CHANGE_TYPE" "$CHILD_ACCOUNT_ID" "$PIPELINES_AUTH_ROLE"
+        ;;
+esac

--- a/scripts/setup-action-configs.sh
+++ b/scripts/setup-action-configs.sh
@@ -17,6 +17,7 @@ NEW_ACCOUNT_NAME="${NEW_ACCOUNT_NAME:-}"
 TEAM_ACCOUNT_NAMES="${TEAM_ACCOUNT_NAMES:-}"
 CHILD_ACCOUNT_ID="${CHILD_ACCOUNT_ID:-}"
 PIPELINES_AUTH_ROLE="${PIPELINES_AUTH_ROLE:-}"
+TEAM_ACCOUNT_DATA="${TEAM_ACCOUNT_DATA:-}"
 
 check_pipeline_is_installed() {
     if ! command -v pipelines &> /dev/null; then
@@ -72,7 +73,7 @@ handle_account_request() {
 
 handle_account_added() {
     readonly management_account="$1"
-    readonly new_account_name="$2"
+    readonly child_account="$2"
     readonly branch="$3"
     readonly infra_live_repo="$4"
     readonly working_directory="$5"
@@ -82,14 +83,14 @@ handle_account_added() {
     echo "workflow=apply-new-account-baseline.yml" >> "$GITHUB_OUTPUT"
     workflow_inputs="$(jq -c -n \
         --arg management_account "$management_account" \
-        --arg new_account_name "$new_account_name" \
+        --arg child_account "$child_account" \
         --arg branch "$branch" \
         --arg infra_live_repo "$infra_live_repo" \
         --arg working_directory "$working_directory" \
         --arg terragrunt_command "$terragrunt_command" \
         '{
             "management_account": $management_account,
-            "new_account_name": $new_account_name,
+            "child_account": $child_account,
             "branch": $branch,
             "infra_live_repo": $infra_live_repo,
             "working_directory": $working_directory,
@@ -118,12 +119,14 @@ handle_team_accounts_requested() {
         --arg infra_live_repo "$infra_live_repo" \
         --arg working_directory "$working_directory" \
         --arg terragrunt_command "$terragrunt_command" \
+        --arg team_account_names "$team_account_names" \
         '{
             "management_account": $management_account,
             "branch": $branch,
             "infra_live_repo": $infra_live_repo,
             "working_directory": $working_directory,
-            "terragrunt_command": $terragrunt_command
+            "terragrunt_command": $terragrunt_command,
+            "team_account_names": $team_account_names
         }'
     )"
     if [[ -n "${pipelines_auth_role:-}" ]]; then
@@ -138,7 +141,7 @@ handle_team_accounts_added() {
     readonly infra_live_repo="$3"
     readonly working_directory="$4"
     readonly terragrunt_command="$5"
-    readonly team_account_names="$6"
+    readonly team_account_data="$6"
     readonly pipelines_auth_role="$7"
 
     echo "workflow=apply-new-sdlc-accounts-baseline.yml" >> "$GITHUB_OUTPUT"
@@ -148,14 +151,14 @@ handle_team_accounts_added() {
         --arg infra_live_repo "$infra_live_repo" \
         --arg working_directory "$working_directory" \
         --arg terragrunt_command "$terragrunt_command" \
-        --arg team_account_names "$team_account_names" \
+        --arg team_account_data "$team_account_data" \
         '{
             "management_account": $management_account,
             "branch": $branch,
             "infra_live_repo": $infra_live_repo,
             "working_directory": $working_directory,
             "terragrunt_command": $terragrunt_command,
-            "team_account_names": $team_account_names
+            "team_account_data": $team_account_data
         }'
     )
     if [[ -n "${pipelines_auth_role:-}" ]]; then
@@ -209,7 +212,7 @@ case "$CHANGE_TYPE" in
         handle_team_accounts_requested "$MANAGEMENT_ACCOUNT" "$BRANCH" "$INFRA_LIVE_REPO" "$WORKING_DIRECTORY" "$COMMAND $ARGS" "$TEAM_ACCOUNT_NAMES" "$PIPELINES_AUTH_ROLE"
         ;;
     TeamAccountsAdded)
-        handle_team_accounts_added "$MANAGEMENT_ACCOUNT" "$BRANCH" "$INFRA_LIVE_REPO" "$WORKING_DIRECTORY" "$COMMAND $ARGS" "$TEAM_ACCOUNT_NAMES" "$PIPELINES_AUTH_ROLE"
+        handle_team_accounts_added "$MANAGEMENT_ACCOUNT" "$BRANCH" "$INFRA_LIVE_REPO" "$WORKING_DIRECTORY" "$COMMAND $ARGS" "$TEAM_ACCOUNT_DATA" "$PIPELINES_AUTH_ROLE"
         ;;
     *)
         handle_default "$MANAGEMENT_ACCOUNT" "$BRANCH" "$INFRA_LIVE_REPO" "$WORKING_DIRECTORY" "$COMMAND $ARGS" "$CHANGE_TYPE" "$CHILD_ACCOUNT_ID" "$PIPELINES_AUTH_ROLE"

--- a/scripts/setup-action-configs.sh
+++ b/scripts/setup-action-configs.sh
@@ -64,7 +64,7 @@ handle_account_request() {
             "terragrunt_command": $terragrunt_command
         }'
     )"
-    if [[ -n "$pipelines_auth_role" ]]; then
+    if [[ -n "${pipelines_auth_role:-}" ]]; then
         workflow_inputs="$(append_presigned_caller_identity_token "$workflow_inputs")"
     fi
     echo "workflow_inputs=$workflow_inputs" >> "$GITHUB_OUTPUT"
@@ -96,7 +96,7 @@ handle_account_added() {
             "terragrunt_command": $terragrunt_command
         }'
     )"
-    if [[ -n "$pipelines_auth_role" ]]; then
+    if [[ -n "${pipelines_auth_role:-}" ]]; then
         workflow_inputs="$(append_presigned_caller_identity_token "$workflow_inputs")"
     fi
     echo "workflow_inputs=$workflow_inputs" >> "$GITHUB_OUTPUT"
@@ -126,7 +126,7 @@ handle_team_accounts_requested() {
             "terragrunt_command": $terragrunt_command
         }'
     )"
-    if [[ -n "$pipelines_auth_role" ]]; then
+    if [[ -n "${pipelines_auth_role:-}" ]]; then
         workflow_inputs="$(append_presigned_caller_identity_token "$workflow_inputs")"
     fi
     echo "workflow_inputs=$workflow_inputs" >> "$GITHUB_OUTPUT"
@@ -158,7 +158,7 @@ handle_team_accounts_added() {
             "team_account_names": $team_account_names
         }'
     )
-    if [[ -n "$pipelines_auth_role" ]]; then
+    if [[ -n "${pipelines_auth_role:-}" ]]; then
         workflow_inputs="$(append_presigned_caller_identity_token "$workflow_inputs")"
     fi
     echo "workflow_inputs=$workflow_inputs" >> "$GITHUB_OUTPUT"
@@ -192,7 +192,7 @@ handle_default() {
             "child_account_id": $child_account_id
         }'
     )
-    if [[ -n "$pipelines_auth_role" ]]; then
+    if [[ -n "${pipelines_auth_role:-}" ]]; then
         workflow_inputs="$(append_presigned_caller_identity_token "$workflow_inputs")"
     fi
     echo "workflow_inputs=$workflow_inputs" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

This adds three extra inputs to the action to allow for the `pipelines auth presign` command to be run and passed to infrastructure-piplines as an additional, optional workflow input `presigned_caller_identity`.

## Notes

In order to avoid having this be a breaking change on either the `workflow-dispatch` side or the `infrastructure-pipelines` side, the new inputs that are being introduced here are optional, and will not change existing functionality if not provided, and if they are not provided will not impact the inputs passed to `infrastructure-pipelines`.

