### PR TITLE
Setting up action for testing pipelines auth

### DIFF
--- a/.github/workflows/apply-new-account-baseline.yml
+++ b/.github/workflows/apply-new-account-baseline.yml
@@ -32,6 +32,10 @@ on:
         type: string
         description: "The infrastructure live repo on which to run terragrunt"
         required: true
+      presigned_caller_identity:
+        description: "The presigned URL sent by the calling account"
+        required: false
+        type: string
 
 defaults:
   run:

--- a/.github/workflows/apply-new-account-baseline.yml
+++ b/.github/workflows/apply-new-account-baseline.yml
@@ -59,6 +59,7 @@ jobs:
           TERRAGRUNT_COMMAND: ${{ inputs.terragrunt_command }}
           MANAGEMENT_ACCOUNT: ${{ inputs.management_account }}
           CHILD_ACCOUNT: ${{ inputs.child_account }}
+          PRESIGNED_CALLER_IDENTITY: ${{ inputs.presigned_caller_identity }}
         run: |
           # Required Inputs
           echo "BRANCH: $BRANCH"
@@ -67,3 +68,8 @@ jobs:
           echo "TERRAGRUNT_COMMAND: $TERRAGRUNT_COMMAND"
           echo "MANAGEMENT_ACCOUNT: $MANAGEMENT_ACCOUNT"
           echo "CHILD_ACCOUNT: $CHILD_ACCOUNT"
+
+          if [[ $PRESIGNED_CALLER_IDENTITY != "fake token" ]]; then
+            echo "Did not receive expected presigned caller identity"
+            exit 1
+          fi

--- a/.github/workflows/apply-new-account-baseline.yml
+++ b/.github/workflows/apply-new-account-baseline.yml
@@ -61,20 +61,45 @@ jobs:
           CHILD_ACCOUNT: ${{ inputs.child_account }}
           PRESIGNED_CALLER_IDENTITY: ${{ inputs.presigned_caller_identity }}
         run: |
-          # Required Inputs
-          echo "BRANCH: $BRANCH"
-          echo "INFRA_LIVE_REPO: $INFRA_LIVE_REPO"
-          echo "WORKING_DIRECTORY: $WORKING_DIRECTORY"
-          echo "TERRAGRUNT_COMMAND: $TERRAGRUNT_COMMAND"
-          echo "MANAGEMENT_ACCOUNT: $MANAGEMENT_ACCOUNT"
-          echo "CHILD_ACCOUNT: $CHILD_ACCOUNT"
+          # These verify the expected values sent by the workflow dispatch to this workflow in `infrastructure-pipelines`
+          # When `pipelines-dispatch` is called with the values found in `test-caller.yml`.
+
+          if [[ $MANAGEMENT_ACCOUNT != "123" ]]; then
+            echo "Did not receive expected management account"
+            exit 1
+          fi
+
+          if [[ $CHILD_ACCOUNT != "new_account_name" ]]; then
+            echo "Did not receive expected child account"
+            exit 1
+          fi
+
+          if [[ -z $BRANCH ]]; then
+            echo "Did not set branch"
+            exit 1
+          fi
+
+          if [[ $INFRA_LIVE_REPO != "gruntwork-io/pipelines-dispatch" ]]; then
+            echo "Did not receive expected infra live repo"
+            exit 1
+          fi
+
+          if [[ $WORKING_DIRECTORY != "." ]]; then
+            echo "Did not receive expected working directory"
+            exit 1
+          fi
+
+          if [[ $TERRAGRUNT_COMMAND != "command args" ]]; then
+            echo "Did not receive expected terragrunt command"
+            exit 1
+          fi
 
           if [[ -z ${PRESIGNED_CALLER_IDENTITY:-} ]]; then
-            echo "PRESIGNED_CALLER_IDENTITY is not set"
+            echo "PRESIGNED_CALLER_IDENTITY is not set, which is expected when `presign_token` is `true` in `pipelines-dispatch`"
             exit 0
           fi
 
           if [[ ${PRESIGNED_CALLER_IDENTITY} != "fake token" ]]; then
-            echo "Did not receive expected presigned caller identity"
+            echo "Did not receive expected presigned caller identity, which is expected when `presign_token` is `true` in `pipelines-dispatch`"
             exit 1
           fi

--- a/.github/workflows/apply-new-account-baseline.yml
+++ b/.github/workflows/apply-new-account-baseline.yml
@@ -69,7 +69,7 @@ jobs:
           echo "MANAGEMENT_ACCOUNT: $MANAGEMENT_ACCOUNT"
           echo "CHILD_ACCOUNT: $CHILD_ACCOUNT"
 
-          if [[ $PRESIGNED_CALLER_IDENTITY != "fake token" ]]; then
+          if [[ ${PRESIGNED_CALLER_IDENTITY:-} != "fake token" ]]; then
             echo "Did not receive expected presigned caller identity"
             exit 1
           fi

--- a/.github/workflows/apply-new-account-baseline.yml
+++ b/.github/workflows/apply-new-account-baseline.yml
@@ -69,7 +69,12 @@ jobs:
           echo "MANAGEMENT_ACCOUNT: $MANAGEMENT_ACCOUNT"
           echo "CHILD_ACCOUNT: $CHILD_ACCOUNT"
 
-          if [[ ${PRESIGNED_CALLER_IDENTITY:-} != "fake token" ]]; then
+          if [[ -z ${PRESIGNED_CALLER_IDENTITY:-} ]]; then
+            echo "PRESIGNED_CALLER_IDENTITY is not set"
+            exit 0
+          fi
+
+          if [[ ${PRESIGNED_CALLER_IDENTITY} != "fake token" ]]; then
             echo "Did not receive expected presigned caller identity"
             exit 1
           fi

--- a/.github/workflows/apply-new-sdlc-accounts-baseline.yml
+++ b/.github/workflows/apply-new-sdlc-accounts-baseline.yml
@@ -69,7 +69,12 @@ jobs:
           echo "MANAGEMENT_ACCOUNT: $MANAGEMENT_ACCOUNT"
           echo "TEAM_ACCOUNT_DATA: $TEAM_ACCOUNT_DATA"
 
-          if [[ ${PRESIGNED_CALLER_IDENTITY:-} != "fake token" ]]; then
+          if [[ -z ${PRESIGNED_CALLER_IDENTITY:-} ]]; then
+            echo "PRESIGNED_CALLER_IDENTITY is not set"
+            exit 0
+          fi
+
+          if [[ ${PRESIGNED_CALLER_IDENTITY} != "fake token" ]]; then
             echo "Did not receive expected presigned caller identity"
             exit 1
           fi

--- a/.github/workflows/apply-new-sdlc-accounts-baseline.yml
+++ b/.github/workflows/apply-new-sdlc-accounts-baseline.yml
@@ -59,6 +59,7 @@ jobs:
           TERRAGRUNT_COMMAND: ${{ inputs.terragrunt_command }}
           MANAGEMENT_ACCOUNT: ${{ inputs.management_account }}
           TEAM_ACCOUNT_DATA: ${{ inputs.team_account_data }}
+          PRESIGNED_CALLER_IDENTITY: ${{ inputs.presigned_caller_identity }}
         run: |
           # Required Inputs
           echo "BRANCH: $BRANCH"
@@ -67,3 +68,8 @@ jobs:
           echo "TERRAGRUNT_COMMAND: $TERRAGRUNT_COMMAND"
           echo "MANAGEMENT_ACCOUNT: $MANAGEMENT_ACCOUNT"
           echo "TEAM_ACCOUNT_DATA: $TEAM_ACCOUNT_DATA"
+
+          if [[ $PRESIGNED_CALLER_IDENTITY != "fake token" ]]; then
+            echo "Did not receive expected presigned caller identity"
+            exit 1
+          fi

--- a/.github/workflows/apply-new-sdlc-accounts-baseline.yml
+++ b/.github/workflows/apply-new-sdlc-accounts-baseline.yml
@@ -61,20 +61,45 @@ jobs:
           TEAM_ACCOUNT_DATA: ${{ inputs.team_account_data }}
           PRESIGNED_CALLER_IDENTITY: ${{ inputs.presigned_caller_identity }}
         run: |
-          # Required Inputs
-          echo "BRANCH: $BRANCH"
-          echo "INFRA_LIVE_REPO: $INFRA_LIVE_REPO"
-          echo "WORKING_DIRECTORY: $WORKING_DIRECTORY"
-          echo "TERRAGRUNT_COMMAND: $TERRAGRUNT_COMMAND"
-          echo "MANAGEMENT_ACCOUNT: $MANAGEMENT_ACCOUNT"
-          echo "TEAM_ACCOUNT_DATA: $TEAM_ACCOUNT_DATA"
+          # These verify the expected values sent by the workflow dispatch to this workflow in `infrastructure-pipelines`
+          # When `pipelines-dispatch` is called with the values found in `test-caller.yml`.
+
+          if [[ $MANAGEMENT_ACCOUNT != "123" ]]; then
+            echo "Did not receive expected management account"
+            exit 1
+          fi
+
+          if [[ -z $BRANCH ]]; then
+            echo "Did not set branch"
+            exit 1
+          fi
+
+          if [[ $INFRA_LIVE_REPO != "gruntwork-io/pipelines-dispatch" ]]; then
+            echo "Did not receive expected infra live repo"
+            exit 1
+          fi
+
+          if [[ $WORKING_DIRECTORY != "." ]]; then
+            echo "Did not receive expected working directory"
+            exit 1
+          fi
+
+          if [[ $TERRAGRUNT_COMMAND != "command args" ]]; then
+            echo "Did not receive expected terragrunt command"
+            exit 1
+          fi
+
+          if [[ $TEAM_ACCOUNT_DATA != "{\n  \"AccountName\": \"new_account_name\",\n  \"ChildAccountId\": \"child_account_id\",\n  \"TeamAccountNames\": [\"team_account_names\"]\n}\n" ]]; then
+            echo "Did not receive expected team account data"
+            exit 1
+          fi
 
           if [[ -z ${PRESIGNED_CALLER_IDENTITY:-} ]]; then
-            echo "PRESIGNED_CALLER_IDENTITY is not set"
+            echo "PRESIGNED_CALLER_IDENTITY is not set, which is expected when `presign_token` is `true` in `pipelines-dispatch`"
             exit 0
           fi
 
           if [[ ${PRESIGNED_CALLER_IDENTITY} != "fake token" ]]; then
-            echo "Did not receive expected presigned caller identity"
+            echo "Did not receive expected presigned caller identity, which is expected when `presign_token` is `true` in `pipelines-dispatch`"
             exit 1
           fi

--- a/.github/workflows/apply-new-sdlc-accounts-baseline.yml
+++ b/.github/workflows/apply-new-sdlc-accounts-baseline.yml
@@ -69,7 +69,7 @@ jobs:
           echo "MANAGEMENT_ACCOUNT: $MANAGEMENT_ACCOUNT"
           echo "TEAM_ACCOUNT_DATA: $TEAM_ACCOUNT_DATA"
 
-          if [[ $PRESIGNED_CALLER_IDENTITY != "fake token" ]]; then
+          if [[ ${PRESIGNED_CALLER_IDENTITY:-} != "fake token" ]]; then
             echo "Did not receive expected presigned caller identity"
             exit 1
           fi

--- a/.github/workflows/apply-new-sdlc-accounts-baseline.yml
+++ b/.github/workflows/apply-new-sdlc-accounts-baseline.yml
@@ -32,6 +32,10 @@ on:
         description: "The folder path in which terragrunt will execute"
         required: true
         type: string
+      presigned_caller_identity:
+        description: "The presigned URL sent by the calling account"
+        required: false
+        type: string
 
 defaults:
   run:

--- a/.github/workflows/create-account-and-generate-baselines.yml
+++ b/.github/workflows/create-account-and-generate-baselines.yml
@@ -52,6 +52,7 @@ jobs:
           TERRAGRUNT_COMMAND: ${{ inputs.terragrunt_command }}
           MANAGEMENT_ACCOUNT: ${{ inputs.management_account }}
           NEW_ACCOUNT_NAME: ${{ inputs.new_account_name }}
+          PRESIGNED_CALLER_IDENTITY: ${{ inputs.presigned_caller_identity }}
         run: |
           # Required Inputs
           echo "BRANCH: $BRANCH"
@@ -60,3 +61,8 @@ jobs:
           echo "TERRAGRUNT_COMMAND: $TERRAGRUNT_COMMAND"
           echo "MANAGEMENT_ACCOUNT: $MANAGEMENT_ACCOUNT"
           echo "NEW_ACCOUNT_NAME: $NEW_ACCOUNT_NAME"
+
+          if [[ $PRESIGNED_CALLER_IDENTITY != "fake token" ]]; then
+            echo "Did not receive expected presigned caller identity"
+            exit 1
+          fi

--- a/.github/workflows/create-account-and-generate-baselines.yml
+++ b/.github/workflows/create-account-and-generate-baselines.yml
@@ -25,6 +25,10 @@ on:
       terragrunt_command:
         description: "Terragrunt Command"
         required: true
+      presigned_caller_identity:
+        description: "The presigned URL sent by the calling account"
+        required: false
+        type: string
 
 defaults:
   run:

--- a/.github/workflows/create-account-and-generate-baselines.yml
+++ b/.github/workflows/create-account-and-generate-baselines.yml
@@ -62,7 +62,7 @@ jobs:
           echo "MANAGEMENT_ACCOUNT: $MANAGEMENT_ACCOUNT"
           echo "NEW_ACCOUNT_NAME: $NEW_ACCOUNT_NAME"
 
-          if [[ $PRESIGNED_CALLER_IDENTITY != "fake token" ]]; then
+          if [[ ${PRESIGNED_CALLER_IDENTITY:-} != "fake token" ]]; then
             echo "Did not receive expected presigned caller identity"
             exit 1
           fi

--- a/.github/workflows/create-account-and-generate-baselines.yml
+++ b/.github/workflows/create-account-and-generate-baselines.yml
@@ -54,20 +54,45 @@ jobs:
           NEW_ACCOUNT_NAME: ${{ inputs.new_account_name }}
           PRESIGNED_CALLER_IDENTITY: ${{ inputs.presigned_caller_identity }}
         run: |
-          # Required Inputs
-          echo "BRANCH: $BRANCH"
-          echo "INFRA_LIVE_REPO: $INFRA_LIVE_REPO"
-          echo "WORKING_DIRECTORY: $WORKING_DIRECTORY"
-          echo "TERRAGRUNT_COMMAND: $TERRAGRUNT_COMMAND"
-          echo "MANAGEMENT_ACCOUNT: $MANAGEMENT_ACCOUNT"
-          echo "NEW_ACCOUNT_NAME: $NEW_ACCOUNT_NAME"
+          # These verify the expected values sent by the workflow dispatch to this workflow in `infrastructure-pipelines`
+          # When `pipelines-dispatch` is called with the values found in `test-caller.yml`.
+
+          if [[ $MANAGEMENT_ACCOUNT != "123" ]]; then
+            echo "MANAGEMENT_ACCOUNT is not set to expected value"
+            exit 1
+          fi
+
+          if [[ $NEW_ACCOUNT_NAME != "new_account_name" ]]; then
+            echo "NEW_ACCOUNT_NAME is not set to expected value"
+            exit 1
+          fi
+
+          if [[ -z $BRANCH ]]; then
+            echo "BRANCH is not set"
+            exit 1
+          fi
+
+          if [[ $INFRA_LIVE_REPO != "gruntwork-io/pipelines-dispatch" ]]; then
+            echo "INFRA_LIVE_REPO is not set to expected value"
+            exit 1
+          fi
+
+          if [[ $WORKING_DIRECTORY != "." ]]; then
+            echo "WORKING_DIRECTORY is not set to expected value"
+            exit 1
+          fi
+
+          if [[ $TERRAGRUNT_COMMAND != "command args" ]]; then
+            echo "TERRAGRUNT_COMMAND is not set to expected value"
+            exit 1
+          fi
 
           if [[ -z ${PRESIGNED_CALLER_IDENTITY:-} ]]; then
-            echo "PRESIGNED_CALLER_IDENTITY is not set"
+            echo "PRESIGNED_CALLER_IDENTITY is not set, which is expected when `presign_token` is `true` in `pipelines-dispatch`"
             exit 0
           fi
 
           if [[ ${PRESIGNED_CALLER_IDENTITY} != "fake token" ]]; then
-            echo "Did not receive expected presigned caller identity"
+            echo "Did not receive expected presigned caller identity, which is expected when `presign_token` is `true` in `pipelines-dispatch`"
             exit 1
           fi

--- a/.github/workflows/create-account-and-generate-baselines.yml
+++ b/.github/workflows/create-account-and-generate-baselines.yml
@@ -62,7 +62,12 @@ jobs:
           echo "MANAGEMENT_ACCOUNT: $MANAGEMENT_ACCOUNT"
           echo "NEW_ACCOUNT_NAME: $NEW_ACCOUNT_NAME"
 
-          if [[ ${PRESIGNED_CALLER_IDENTITY:-} != "fake token" ]]; then
+          if [[ -z ${PRESIGNED_CALLER_IDENTITY:-} ]]; then
+            echo "PRESIGNED_CALLER_IDENTITY is not set"
+            exit 0
+          fi
+
+          if [[ ${PRESIGNED_CALLER_IDENTITY} != "fake token" ]]; then
             echo "Did not receive expected presigned caller identity"
             exit 1
           fi

--- a/.github/workflows/create-sdlc-accounts-and-generate-baselines.yml
+++ b/.github/workflows/create-sdlc-accounts-and-generate-baselines.yml
@@ -60,20 +60,45 @@ jobs:
           TEAM_ACCOUNT_NAMES: ${{ inputs.team_account_names }}
           PRESIGNED_CALLER_IDENTITY: ${{ inputs.presigned_caller_identity }}
         run: |
-          # Required Inputs
-          echo "BRANCH: $BRANCH"
-          echo "INFRA_LIVE_REPO: $INFRA_LIVE_REPO"
-          echo "WORKING_DIRECTORY: $WORKING_DIRECTORY"
-          echo "TERRAGRUNT_COMMAND: $TERRAGRUNT_COMMAND"
-          echo "MANAGEMENT_ACCOUNT: $MANAGEMENT_ACCOUNT"
-          echo "TEAM_ACCOUNT_NAMES: $TEAM_ACCOUNT_NAMES"
+          # These verify the expected values sent by the workflow dispatch to this workflow in `infrastructure-pipelines`
+          # When `pipelines-dispatch` is called with the values found in `test-caller.yml`.
+
+          if [[ $MANAGEMENT_ACCOUNT != "123" ]]; then
+            echo "MANAGEMENT_ACCOUNT is not set to expected value"
+            exit 1
+          fi
+
+          if [[ -z $BRANCH ]]; then
+            echo "BRANCH is not set"
+            exit 1
+          fi
+
+          if [[ $INFRA_LIVE_REPO != "gruntwork-io/pipelines-dispatch" ]]; then
+            echo "INFRA_LIVE_REPO is not set to expected value"
+            exit 1
+          fi
+
+          if [[ $WORKING_DIRECTORY != "." ]]; then
+            echo "WORKING_DIRECTORY is not set to expected value"
+            exit 1
+          fi
+
+          if [[ $TERRAGRUNT_COMMAND != "command args" ]]; then
+            echo "TERRAGRUNT_COMMAND is not set to expected value"
+            exit 1
+          fi
+
+          if [[ $TEAM_ACCOUNT_NAMES != '[\n  \"team_account_names\"\n]' ]]; then
+            echo "TEAM_ACCOUNT_NAMES is not set to expected value"
+            exit 1
+          fi
 
           if [[ -z ${PRESIGNED_CALLER_IDENTITY:-} ]]; then
-            echo "PRESIGNED_CALLER_IDENTITY is not set"
+            echo "PRESIGNED_CALLER_IDENTITY is not set, which is expected when `presign_token` is `true` in `pipelines-dispatch`"
             exit 0
           fi
 
           if [[ ${PRESIGNED_CALLER_IDENTITY} != "fake token" ]]; then
-            echo "Did not receive expected presigned caller identity"
+            echo "Did not receive expected presigned caller identity, which is expected when `presign_token` is `true` in `pipelines-dispatch`"
             exit 1
           fi

--- a/.github/workflows/create-sdlc-accounts-and-generate-baselines.yml
+++ b/.github/workflows/create-sdlc-accounts-and-generate-baselines.yml
@@ -32,6 +32,10 @@ on:
         type: string
         description: "The names of the team accounts to create"
         required: true
+      presigned_caller_identity:
+        description: "The presigned URL sent by the calling account"
+        required: false
+        type: string
 
 defaults:
   run:

--- a/.github/workflows/create-sdlc-accounts-and-generate-baselines.yml
+++ b/.github/workflows/create-sdlc-accounts-and-generate-baselines.yml
@@ -68,7 +68,12 @@ jobs:
           echo "MANAGEMENT_ACCOUNT: $MANAGEMENT_ACCOUNT"
           echo "TEAM_ACCOUNT_NAMES: $TEAM_ACCOUNT_NAMES"
 
-          if [[ ${PRESIGNED_CALLER_IDENTITY:-} != "fake token" ]]; then
+          if [[ -z ${PRESIGNED_CALLER_IDENTITY:-} ]]; then
+            echo "PRESIGNED_CALLER_IDENTITY is not set"
+            exit 0
+          fi
+
+          if [[ ${PRESIGNED_CALLER_IDENTITY} != "fake token" ]]; then
             echo "Did not receive expected presigned caller identity"
             exit 1
           fi

--- a/.github/workflows/create-sdlc-accounts-and-generate-baselines.yml
+++ b/.github/workflows/create-sdlc-accounts-and-generate-baselines.yml
@@ -68,7 +68,7 @@ jobs:
           echo "MANAGEMENT_ACCOUNT: $MANAGEMENT_ACCOUNT"
           echo "TEAM_ACCOUNT_NAMES: $TEAM_ACCOUNT_NAMES"
 
-          if [[ $PRESIGNED_CALLER_IDENTITY != "fake token" ]]; then
+          if [[ ${PRESIGNED_CALLER_IDENTITY:-} != "fake token" ]]; then
             echo "Did not receive expected presigned caller identity"
             exit 1
           fi

--- a/.github/workflows/create-sdlc-accounts-and-generate-baselines.yml
+++ b/.github/workflows/create-sdlc-accounts-and-generate-baselines.yml
@@ -58,6 +58,7 @@ jobs:
           TERRAGRUNT_COMMAND: ${{ inputs.terragrunt_command }}
           MANAGEMENT_ACCOUNT: ${{ inputs.management_account }}
           TEAM_ACCOUNT_NAMES: ${{ inputs.team_account_names }}
+          PRESIGNED_CALLER_IDENTITY: ${{ inputs.presigned_caller_identity }}
         run: |
           # Required Inputs
           echo "BRANCH: $BRANCH"
@@ -66,3 +67,8 @@ jobs:
           echo "TERRAGRUNT_COMMAND: $TERRAGRUNT_COMMAND"
           echo "MANAGEMENT_ACCOUNT: $MANAGEMENT_ACCOUNT"
           echo "TEAM_ACCOUNT_NAMES: $TEAM_ACCOUNT_NAMES"
+
+          if [[ $PRESIGNED_CALLER_IDENTITY != "fake token" ]]; then
+            echo "Did not receive expected presigned caller identity"
+            exit 1
+          fi

--- a/.github/workflows/terragrunt-executor.yml
+++ b/.github/workflows/terragrunt-executor.yml
@@ -89,7 +89,13 @@ jobs:
           echo "PIPELINES_CHANGE_TYPE: $PIPELINES_CHANGE_TYPE"
           echo "CHILD_ACCOUNT_ID: ${CHILD_ACCOUNT_ID:-}"
 
-          if [[ ${PRESIGNED_CALLER_IDENTITY:-} != "fake token" ]]; then
+          # We only need to check that when PRESIGNED_CALLER_IDENTITY is set
+          if [[ -z ${PRESIGNED_CALLER_IDENTITY:-} ]]; then
+            echo "PRESIGNED_CALLER_IDENTITY is not set"
+            exit 0
+          fi
+
+          if [[ ${PRESIGNED_CALLER_IDENTITY} != "fake token" ]]; then
             echo "Did not receive expected presigned caller identity"
             exit 1
           fi

--- a/.github/workflows/terragrunt-executor.yml
+++ b/.github/workflows/terragrunt-executor.yml
@@ -78,6 +78,7 @@ jobs:
           ACCOUNT: ${{ inputs.account }}
           PIPELINES_CHANGE_TYPE: ${{ inputs.pipelines_change_type }}
           CHILD_ACCOUNT_ID: ${{ inputs.child_account_id }}
+          PRESIGNED_CALLER_IDENTITY: ${{ inputs.presigned_caller_identity }}
         run: |
           # Required Inputs
           echo "BRANCH: $BRANCH"
@@ -87,3 +88,8 @@ jobs:
           echo "ACCOUNT: $ACCOUNT"
           echo "PIPELINES_CHANGE_TYPE: $PIPELINES_CHANGE_TYPE"
           echo "CHILD_ACCOUNT_ID: ${CHILD_ACCOUNT_ID:-}"
+
+          if [[ $PRESIGNED_CALLER_IDENTITY != "fake token" ]]; then
+            echo "Did not receive expected presigned caller identity"
+            exit 1
+          fi

--- a/.github/workflows/terragrunt-executor.yml
+++ b/.github/workflows/terragrunt-executor.yml
@@ -89,7 +89,7 @@ jobs:
           echo "PIPELINES_CHANGE_TYPE: $PIPELINES_CHANGE_TYPE"
           echo "CHILD_ACCOUNT_ID: ${CHILD_ACCOUNT_ID:-}"
 
-          if [[ $PRESIGNED_CALLER_IDENTITY != "fake token" ]]; then
+          if [[ ${PRESIGNED_CALLER_IDENTITY:-} != "fake token" ]]; then
             echo "Did not receive expected presigned caller identity"
             exit 1
           fi

--- a/.github/workflows/terragrunt-executor.yml
+++ b/.github/workflows/terragrunt-executor.yml
@@ -80,21 +80,45 @@ jobs:
           CHILD_ACCOUNT_ID: ${{ inputs.child_account_id }}
           PRESIGNED_CALLER_IDENTITY: ${{ inputs.presigned_caller_identity }}
         run: |
-          # Required Inputs
-          echo "BRANCH: $BRANCH"
-          echo "INFRA_LIVE_REPO: $INFRA_LIVE_REPO"
-          echo "WORKING_DIRECTORY: $WORKING_DIRECTORY"
-          echo "TERRAGRUNT_COMMAND: $TERRAGRUNT_COMMAND"
-          echo "ACCOUNT: $ACCOUNT"
-          echo "PIPELINES_CHANGE_TYPE: $PIPELINES_CHANGE_TYPE"
-          echo "CHILD_ACCOUNT_ID: ${CHILD_ACCOUNT_ID:-}"
+          # These verify the expected values sent by the workflow dispatch to this workflow in `infrastructure-pipelines`
+          # When `pipelines-dispatch` is called with the values found in `test-caller.yml`.
+
+          if [[ $ACCOUNT != "123" ]]; then
+            echo "ACCOUNT is not set to expected value"
+            exit 1
+          fi
+
+          if [[ -z $BRANCH ]]; then
+            echo "BRANCH is not set"
+            exit 1
+          fi
+
+          if [[ $INFRA_LIVE_REPO != "gruntwork-io/pipelines-dispatch" ]]; then
+            echo "INFRA_LIVE_REPO is not set to expected value"
+            exit 1
+          fi
+
+          if [[ $WORKING_DIRECTORY != "." ]]; then
+            echo "WORKING_DIRECTORY is not set to expected value"
+            exit 1
+          fi
+
+          if [[ $TERRAGRUNT_COMMAND != "command args" ]]; then
+            echo "TERRAGRUNT_COMMAND is not set to expected value"
+            exit 1
+          fi
+
+          if [[ -z $PIPELINES_CHANGE_TYPE ]]; then
+            echo "PIPELINES_CHANGE_TYPE is not set"
+            exit 1
+          fi
 
           if [[ -z ${PRESIGNED_CALLER_IDENTITY:-} ]]; then
-            echo "PRESIGNED_CALLER_IDENTITY is not set"
+            echo "PRESIGNED_CALLER_IDENTITY is not set, which is expected when `presign_token` is `true` in `pipelines-dispatch`"
             exit 0
           fi
 
           if [[ ${PRESIGNED_CALLER_IDENTITY} != "fake token" ]]; then
-            echo "Did not receive expected presigned caller identity"
+            echo "Did not receive expected presigned caller identity, which is expected when `presign_token` is `true` in `pipelines-dispatch`"
             exit 1
           fi

--- a/.github/workflows/terragrunt-executor.yml
+++ b/.github/workflows/terragrunt-executor.yml
@@ -52,6 +52,10 @@ on:
         description: "The AWS Account ID of the child account"
         required: false
         type: string
+      presigned_caller_identity:
+        description: "The presigned URL sent by the calling account"
+        required: false
+        type: string
 
 defaults:
   run:

--- a/.github/workflows/test-caller.yml
+++ b/.github/workflows/test-caller.yml
@@ -17,27 +17,37 @@ jobs:
       max-parallel: 2
       matrix:
         change_type:
-            - ModuleChanged
-            - ModuleDeleted
-            - ModuleAdded
-            - ModulesAdded
-            - EnvCommonChanged
-            - EnvCommonDeleted
-            - EnvCommonAdded
-            - AccountRequested
-            - TeamAccountsRequested
-            - AccountAdded
-            - TeamAccountsAdded
-            - AccountChanged
-            - PipelinesPermissionAdded
-            - PipelinesPermissionChanged
-            - PipelinesPermissionDeleted
-            - PipelinesEnvCommonPermissionAdded
-            - PipelinesEnvCommonPermissionChanged
-            - PipelinesEnvCommonPermissionDeleted
+          - ModuleChanged
+          - ModuleDeleted
+          - ModuleAdded
+          - ModulesAdded
+          - EnvCommonChanged
+          - EnvCommonDeleted
+          - EnvCommonAdded
+          - AccountRequested
+          - TeamAccountsRequested
+          - AccountAdded
+          - TeamAccountsAdded
+          - AccountChanged
+          - PipelinesPermissionAdded
+          - PipelinesPermissionChanged
+          - PipelinesPermissionDeleted
+          - PipelinesEnvCommonPermissionAdded
+          - PipelinesEnvCommonPermissionChanged
+          - PipelinesEnvCommonPermissionDeleted
+        presign:
+          - 'true'
+          - 'false'
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Create fake pipelines binary
+        if: matrix.presign == 'true'
+        run: |
+          sudo echo 'echo "fake token"' > /usr/local/bin/pipelines
+          sudo chmod +x /usr/local/bin/pipelines
 
       - name: Trigger action.yml workflow
         uses: "./"
@@ -59,3 +69,6 @@ jobs:
               "TeamAccountNames": ["team_account_names"]
             }
           actor: "actor"
+          presign_token: ${{ matrix.presign }}
+          install_pipelines_cli: "false"
+          assume_pipelines_auth_role: "false"

--- a/.github/workflows/test-caller.yml
+++ b/.github/workflows/test-caller.yml
@@ -14,27 +14,14 @@ jobs:
 
     strategy:
       # This is to avoid rate limiting issues.
-      max-parallel: 2
+      max-parallel: 1
       matrix:
         change_type:
           - ModuleChanged
-          - ModuleDeleted
-          - ModuleAdded
-          - ModulesAdded
-          - EnvCommonChanged
-          - EnvCommonDeleted
-          - EnvCommonAdded
           - AccountRequested
           - TeamAccountsRequested
           - AccountAdded
           - TeamAccountsAdded
-          - AccountChanged
-          - PipelinesPermissionAdded
-          - PipelinesPermissionChanged
-          - PipelinesPermissionDeleted
-          - PipelinesEnvCommonPermissionAdded
-          - PipelinesEnvCommonPermissionChanged
-          - PipelinesEnvCommonPermissionDeleted
         presign:
           - 'true'
           - 'false'

--- a/.github/workflows/test-caller.yml
+++ b/.github/workflows/test-caller.yml
@@ -1,5 +1,22 @@
 name: Test Trigger Workflow
 
+# This workflow tests the `pipepines-dispatch` in a limited fashion.
+
+# It does this by triggering the `action.yml` workflow, and then checking that the
+# JSON payload sent to the correct workflow has the correct inputs set.
+
+## Limitations
+
+# When testing token presigning it test that that the pipelines-dispatch action correctly invokes the pipelines CLI,
+# and appends the stdout of that operation to the JSON payload sent to the correct workflow.
+
+# It does not test that the pipelines CLI is correctly installed (as it doesn't bother to actually install it as that
+# would require using a token to install the pipelines CLI), or that the `presigned_caller_identity` value is valid
+# (since that requires a valid AWS account).
+
+# Instead, it uses a simple `pipelines` script that just echos a fake token, and tests that the
+# output is set correctly in the JSON payload in the workflow it invokes.
+
 on:
   workflow_dispatch:
   pull_request:

--- a/README.md
+++ b/README.md
@@ -20,9 +20,10 @@ This GitHub Action, named "Pipelines Dispatch," is designed to dispatch Terragru
 
 If these inputs are provided, the action will download the `pipelines` binary and run `pipelines auth presign` to generate a presigned `GetCallerIdentity` request for the specified role and region. The presigned request will be passed to the `infrastructure-pipelines` workflow as an additional input. This is a useful, additional layer of security to ensure that the `infrastructure-pipelines` workflow is being called by a repo it trusts.
 
-- `pipelines_token` (optional): GitHub PAT to download `pipelines` binary. If not provided, the action will not install the binary.
+- `presign_token` (optional): Determines if this action should generate a presigned `GetCallerIdentity` request. If not provided or set to a value other than `true`, the action will not generate a presigned request. If set, the inputs `pipelines_token` and `pipelines_auth_role` are required.
+- `pipelines_token` (optional): GitHub PAT to download `pipelines` binary. If not provided, the action will not install the binary. Will be ignored if `pipelines_token` is not provided or not `true`.
 - `pipelines_cli_version` (optional): The version of the `pipelines` binary to download. If not provided, a default version will be used.
-- `pipelines_auth_role` (optional): The IAM role to assume when running the `pipelines auth presign`. If not provided, the action will not assume a role or perform the presign operation.
+- `pipelines_auth_role` (optional): The IAM role to assume when running the `pipelines auth presign`. If not provided, the action will not assume a role. Will be ignored if `pipelines_token` is not provided or not `true`.
 - `pipelines_auth_region` (optional): The AWS region in which to perform the `pipelines auth presign`. If not provided, the `us-east-1` region will be used.
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ This GitHub Action, named "Pipelines Dispatch," is designed to dispatch Terragru
 - `change_type` (required): The type of infrastructure change that occurred.
 - `additional_data` (optional): Additional data related to the change type.
 - `actor` (required): The GitHub actor responsible for the change.
+- `pipelines_token` (optional): GitHub PAT to download `pipelines` binary. If not provided, the action will not install the binary.
+- `pipelines_cli_version` (optional): The version of the `pipelines` binary to download. If not provided, a default version will be used.
+- `pipelines_auth_role` (optional): The IAM role to assume when running the `pipelines auth presign`. If not provided, the action will not assume a role or perform the presign operation.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ This GitHub Action, named "Pipelines Dispatch," is designed to dispatch Terragru
 - `pipelines_token` (optional): GitHub PAT to download `pipelines` binary. If not provided, the action will not install the binary.
 - `pipelines_cli_version` (optional): The version of the `pipelines` binary to download. If not provided, a default version will be used.
 - `pipelines_auth_role` (optional): The IAM role to assume when running the `pipelines auth presign`. If not provided, the action will not assume a role or perform the presign operation.
+- `pipelines_auth_region` (optional): The AWS region in which to perform the `pipelines auth presign`. If not provided, the `us-east-1` region will be used.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@ This GitHub Action, named "Pipelines Dispatch," is designed to dispatch Terragru
 - `change_type` (required): The type of infrastructure change that occurred.
 - `additional_data` (optional): Additional data related to the change type.
 - `actor` (required): The GitHub actor responsible for the change.
+
+### Pipelines Presign Inputs
+
+If these inputs are provided, the action will download the `pipelines` binary and run `pipelines auth presign` to generate a presigned `GetCallerIdentity` request for the specified role and region. The presigned request will be passed to the `infrastructure-pipelines` workflow as an additional input. This is a useful, additional layer of security to ensure that the `infrastructure-pipelines` workflow is being called by a repo it trusts.
+
 - `pipelines_token` (optional): GitHub PAT to download `pipelines` binary. If not provided, the action will not install the binary.
 - `pipelines_cli_version` (optional): The version of the `pipelines` binary to download. If not provided, a default version will be used.
 - `pipelines_auth_role` (optional): The IAM role to assume when running the `pipelines auth presign`. If not provided, the action will not assume a role or perform the presign operation.

--- a/README.md
+++ b/README.md
@@ -20,11 +20,13 @@ This GitHub Action, named "Pipelines Dispatch," is designed to dispatch Terragru
 
 If these inputs are provided, the action will download the `pipelines` binary and run `pipelines auth presign` to generate a presigned `GetCallerIdentity` request for the specified role and region. The presigned request will be passed to the `infrastructure-pipelines` workflow as an additional input. This is a useful, additional layer of security to ensure that the `infrastructure-pipelines` workflow is being called by a repo it trusts.
 
-- `presign_token` (optional): Determines if this action should generate a presigned `GetCallerIdentity` request. If not provided or set to a value other than `true`, the action will not generate a presigned request. If set, the inputs `pipelines_token` and `pipelines_auth_role` are required.
-- `pipelines_token` (optional): GitHub PAT to download `pipelines` binary. If not provided, the action will not install the binary. Will be ignored if `pipelines_token` is not provided or not `true`.
+- `presign_token` (optional): Determines if this action should generate a presigned `GetCallerIdentity` request. If not set to `true`, the action will not generate a presigned request for verification in `infrastructure-pipelines`.
+- `install_pipelines_cli` (optional): Determines if this action should download the `pipelines` CLI binary. Defaults to `true`. Ignored if `pipelines_token` is not `true`.
+- `assume_auth_role` (optional): Determines if this action should assume a role when running `pipelines auth presign`. Defaults to `true`. Ignored if `pipelines_token` is not `true`.
+- `pipelines_token` (optional): GitHub PAT to download `pipelines` binary. Ignored if `presign_token` and `install_pipelines_cli` are not `true`.
 - `pipelines_cli_version` (optional): The version of the `pipelines` binary to download. If not provided, a default version will be used.
-- `pipelines_auth_role` (optional): The IAM role to assume when running the `pipelines auth presign`. If not provided, the action will not assume a role. Will be ignored if `pipelines_token` is not provided or not `true`.
-- `pipelines_auth_region` (optional): The AWS region in which to perform the `pipelines auth presign`. If not provided, the `us-east-1` region will be used.
+- `pipelines_auth_role` (optional): The IAM role to assume when running the `pipelines auth presign`. Ignored if `presign_token` and `assume_auth_role` are not `true`.
+- `pipelines_auth_region` (optional): The AWS region in which to perform the `pipelines auth presign`. If not provided, the `us-east-1` region will be used. Ignored if `presign_token` and `assume_auth_role` are not `true`.
 
 ## Usage
 

--- a/action.yml
+++ b/action.yml
@@ -57,6 +57,10 @@ inputs:
   actor:
     description: "The github actor responsible for the change"
     required: true
+  presign_token:
+    description: "Presign a `GetCallerIdentity` request to authenticate this repo to the `infrastructure-pipelines` repo"
+    required: false
+    default: "false"
   pipelines_token:
     description: "The GitHub token for downloading the Gruntwork Pipelines binary"
     required: false
@@ -75,25 +79,53 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Validate inputs for presign if enabled
+      shell: bash
+      env:
+        PRESIGN_TOKEN: ${{ inputs.presign_token }}
+        PIPELINES_TOKEN: ${{ inputs.pipelines_token }}
+        PIPELINES_AUTH_ROLE: ${{ inputs.pipelines_auth_role }}
+      run: |
+        if [[ $PRESIGN_TOKEN != "true" ]]; then
+          exit 0
+        fi
+        if [[ $PIPELINES_TOKEN == "" ]]; then
+          echo "Presign token is true, but pipelines token is not set."
+          echo "The pipelines token is required to download the pipelines binary to presign the `GetCallerIdentity` request."
+          exit 1
+        fi
+        if [[ $PIPELINES_AUTH_ROLE == "" ]]; then
+          echo "Presign token is true, but pipelines auth role is not set."
+          echo "The pipelines auth role is required to authenticate the calling repo to the infrastructure-pipelines repo."
+          exit 1
+        fi
+
+    # We only need to install the pipelines CLI if we're presigning a token
+    # and we have a token to use to download the CLI. Clients might decide to
+    # install the CLI before running this action, in which case we don't need
+    # to do it here.
     - name: Download Pipelines CLI
-      if: ${{ inputs.pipelines_token != '' }}
+      if: ${{ inputs.presign_token == 'true' && inputs.pipelines_token != '' }}
       uses: dsaltares/fetch-gh-release-asset@1.1.1
       with:
         repo: "gruntwork-io/pipelines-cli"
         version: "tags/${{ inputs.pipelines_cli_version }}"
         file: "pipelines_linux_amd64"
         target: "/tmp/pipelines"
-        token: ${{ inputs.token }}
+        token: ${{ inputs.pipelines_token }}
 
     - name: Install Pipelines CLI
-      if: ${{ inputs.pipelines_token != '' }}
+      if: ${{ inputs.presign_token == 'true' && inputs.pipelines_token != '' }}
       shell: bash
       run: |
         sudo mv /tmp/pipelines /usr/local/bin/pipelines
         sudo chmod +x /usr/local/bin/pipelines
 
+      # We only need to authenticate with AWS here if we're presigning a token
+      # and we have a role to assume to do so. Clients might decide to assume a role before
+      # running this action, in which case we don't need to do it here.
     - name: Authenticate with AWS
-      if: ${{ inputs.pipelines_auth_role != '' }}
+      if: ${{ inputs.presign_token == 'true' && inputs.pipelines_auth_role != '' }}
       uses: aws-actions/configure-aws-credentials@v4
       with:
         role-to-assume: arn:aws:iam::${{ inputs.account_id }}:role/${{ inputs.pipelines_auth_role }}
@@ -112,7 +144,7 @@ runs:
         COMMAND: ${{ inputs.command }}
         ARGS: ${{ inputs.args }}
         CHILD_ACCOUNT_ID: ${{ fromJSON(inputs.additional_data).ChildAccountId }}
-        PIPELINES_AUTH_ROLE: ${{ inputs.pipelines_auth_role }}
+        PRESIGN_TOKEN: ${{ inputs.presign_token }}
         TEAM_ACCOUNT_NAMES: "${{ toJSON(fromJSON(inputs.additional_data).TeamAccountNames) }}"
         TEAM_ACCOUNT_DATA: ${{ inputs.additional_data }}
       run: ./scripts/setup-action-configs.sh

--- a/action.yml
+++ b/action.yml
@@ -63,7 +63,7 @@ inputs:
   pipelines_cli_version:
     description: "The version of the Gruntwork Pipelines CLI to use"
     required: false
-    default: "0.3.0"
+    default: "0.4.0"
   pipelines_auth_role:
     description: "The role to assume before running `pipelines auth presign`, which is used to authenticate the calling repo. Only necessary when pipelines auth role is provisioned and checked in infrastructure-pipelines repo."
     required: false

--- a/action.yml
+++ b/action.yml
@@ -57,10 +57,48 @@ inputs:
   actor:
     description: "The github actor responsible for the change"
     required: true
+  pipelines_token:
+    description: "The GitHub token for downloading the Gruntwork Pipelines binary"
+    required: false
+  pipelines_cli_version:
+    description: "The version of the Gruntwork Pipelines CLI to use"
+    required: false
+    default: "0.3.0"
+  pipelines_auth_role:
+    description: "The role to assume before running `pipelines auth presign`, which is used to authenticate the calling repo. Only necessary when pipelines auth role is provisioned and checked in infrastructure-pipelines repo."
+    required: false
+  pipelines_auth_region:
+    description: "The region in which the role to assume before running `pipelines auth presign`. Only necessary when pipelines auth role is provisioned and checked in infrastructure-pipelines repo."
+    required: false
+    default: "us-east-1"
 
 runs:
   using: "composite"
   steps:
+    - name: Download Pipelines CLI
+      if: ${{ inputs.pipelines_token != '' }}
+      uses: dsaltares/fetch-gh-release-asset@1.1.1
+      with:
+        repo: "gruntwork-io/pipelines-cli"
+        version: "tags/${{ inputs.pipelines_cli_version }}"
+        file: "pipelines_linux_amd64"
+        target: "/tmp/pipelines"
+        token: ${{ inputs.token }}
+
+    - name: Install Pipelines CLI
+      if: ${{ inputs.pipelines_token != '' }}
+      shell: bash
+      run: |
+        sudo mv /tmp/pipelines /usr/local/bin/pipelines
+        sudo chmod +x /usr/local/bin/pipelines
+
+    - name: Authenticate with AWS
+      if: ${{ inputs.pipelines_auth_role != '' }}
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        role-to-assume: arn:aws:iam::${{ inputs.account_id }}:role/${{ inputs.pipelines_auth_role }}
+        aws-region: ${{ inputs.pipelines_auth_region }}
+
     - name: Setup Action Configurations
       id: setup-action-configurations
       shell: bash
@@ -74,100 +112,8 @@ runs:
         COMMAND: ${{ inputs.command }}
         ARGS: ${{ inputs.args }}
         CHILD_ACCOUNT_ID: ${{ fromJSON(inputs.additional_data).ChildAccountId }}
-      run: |
-        if [[ "$CHANGE_TYPE" == "AccountRequested" ]]; then
-          echo "workflow=create-account-and-generate-baselines.yml" >> "$GITHUB_OUTPUT"
-          echo "workflow_inputs=$(jq -c -n \
-            --arg management_account "$MANAGEMENT_ACCOUNT" \
-            --arg new_account_name "$NEW_ACCOUNT_NAME" \
-            --arg branch "$BRANCH" \
-            --arg infra_live_repo "$INFRA_LIVE_REPO" \
-            --arg working_directory "$WORKING_DIRECTORY" \
-            --arg terragrunt_command "$COMMAND $ARGS" \
-            '{
-              "management_account": $management_account,
-              "new_account_name": $new_account_name,
-              "branch": $branch,
-              "infra_live_repo": $infra_live_repo,
-              "working_directory": $working_directory,
-              "terragrunt_command": $terragrunt_command
-            }'
-          )" >> "$GITHUB_OUTPUT"
-        elif [[ "$CHANGE_TYPE" == "AccountAdded" ]]; then
-          echo "workflow=apply-new-account-baseline.yml" >> "$GITHUB_OUTPUT"
-          echo "workflow_inputs=$(jq -c -n \
-            --arg management_account "$MANAGEMENT_ACCOUNT" \
-            --arg child_account "$NEW_ACCOUNT_NAME" \
-            --arg branch "$BRANCH" \
-            --arg infra_live_repo "$INFRA_LIVE_REPO" \
-            --arg working_directory "$WORKING_DIRECTORY" \
-            --arg terragrunt_command "$COMMAND $ARGS" \
-            '{
-              "management_account": $management_account,
-              "child_account": $child_account,
-              "branch": $branch,
-              "infra_live_repo": $infra_live_repo,
-              "working_directory": $working_directory,
-              "terragrunt_command": $terragrunt_command
-            }'
-          )" >> "$GITHUB_OUTPUT"
-        elif [[ "$CHANGE_TYPE" == "TeamAccountsRequested" ]]; then
-          echo "workflow=create-sdlc-accounts-and-generate-baselines.yml" >> "$GITHUB_OUTPUT"
-          echo "workflow_inputs=$(jq -c -n \
-            --arg management_account "$MANAGEMENT_ACCOUNT" \
-            --arg branch "$BRANCH" \
-            --arg infra_live_repo "$INFRA_LIVE_REPO" \
-            --arg working_directory "$WORKING_DIRECTORY" \
-            --arg terragrunt_command "$COMMAND $ARGS" \
-            --arg team_account_names "$TEAM_ACCOUNT_NAMES" \
-            '{
-              "management_account": $management_account,
-              "branch": $branch,
-              "infra_live_repo": $infra_live_repo,
-              "working_directory": $working_directory,
-              "terragrunt_command": $terragrunt_command,
-              "team_account_names": $team_account_names
-            }'
-          )" >> "$GITHUB_OUTPUT"
-        elif [[ "$CHANGE_TYPE" == "TeamAccountsAdded" ]]; then
-          echo "workflow=apply-new-sdlc-accounts-baseline.yml" >> "$GITHUB_OUTPUT"
-          echo "workflow_inputs=$(jq -c -n \
-            --arg management_account "$MANAGEMENT_ACCOUNT" \
-            --arg branch "$BRANCH" \
-            --arg infra_live_repo "$INFRA_LIVE_REPO" \
-            --arg working_directory "$WORKING_DIRECTORY" \
-            --arg terragrunt_command "$COMMAND $ARGS" \
-            --arg team_account_data "$TEAM_ACCOUNT_DATA" \
-            '{
-              "management_account": $management_account,
-              "branch": $branch,
-              "infra_live_repo": $infra_live_repo,
-              "working_directory": $working_directory,
-              "terragrunt_command": $terragrunt_command,
-              "team_account_data": $team_account_data
-            }'
-          )" >> "$GITHUB_OUTPUT"
-        else
-          echo "workflow=terragrunt-executor.yml" >> "$GITHUB_OUTPUT"
-          echo "workflow_inputs=$(jq -c -n \
-            --arg account "$MANAGEMENT_ACCOUNT" \
-            --arg branch "$BRANCH" \
-            --arg infra_live_repo "$INFRA_LIVE_REPO" \
-            --arg working_directory "$WORKING_DIRECTORY" \
-            --arg terragrunt_command "$COMMAND $ARGS" \
-            --arg pipelines_change_type "$CHANGE_TYPE" \
-            --arg child_account_id "$CHILD_ACCOUNT_ID" \
-            '{
-              "account": $account,
-              "branch": $branch,
-              "infra_live_repo": $infra_live_repo,
-              "working_directory": $working_directory,
-              "terragrunt_command": $terragrunt_command,
-              "pipelines_change_type": $pipelines_change_type,
-              "child_account_id": $child_account_id
-            }'
-          )" >> "$GITHUB_OUTPUT"
-        fi
+        PIPELINES_AUTH_ROLE: ${{ inputs.pipelines_auth_role }}
+      run: ./scripts/setup-action-configurations.sh
 
     - name: Dispatch default workflow and get the run ID
       env:

--- a/action.yml
+++ b/action.yml
@@ -115,7 +115,7 @@ runs:
         PIPELINES_AUTH_ROLE: ${{ inputs.pipelines_auth_role }}
         TEAM_ACCOUNT_NAMES: "${{ toJSON(fromJSON(inputs.additional_data).TeamAccountNames) }}"
         TEAM_ACCOUNT_DATA: ${{ inputs.additional_data }}
-      run: ./scripts/setup-action-configurations.sh
+      run: ./scripts/setup-action-configs.sh
 
     - name: Dispatch default workflow and get the run ID
       env:

--- a/action.yml
+++ b/action.yml
@@ -61,6 +61,14 @@ inputs:
     description: "Presign a `GetCallerIdentity` request to authenticate this repo to the `infrastructure-pipelines` repo"
     required: false
     default: "false"
+  install_pipelines_cli:
+    description: "Install the Gruntwork Pipelines CLI. Ignored if `presign_token` is `false`"
+    required: false
+    default: "true"
+  assume_pipelines_auth_role:
+    description: "Assume the role necessary to run `pipelines auth presign`. Ignored if `presign_token` is `false`"
+    required: false
+    default: "true"
   pipelines_token:
     description: "The GitHub token for downloading the Gruntwork Pipelines binary"
     required: false
@@ -79,24 +87,22 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Validate inputs for presign if enabled
+    - name: Validate Presign Inputs
       shell: bash
+      if: inputs.presign_token == 'true'
       env:
-        PRESIGN_TOKEN: ${{ inputs.presign_token }}
+        INSTALL_PIPELINES_CLI: ${{ inputs.install_pipelines_cli }}
+        ASSUME_PIPELINES_AUTH_ROLE: ${{ inputs.assume_pipelines_auth_role }}
         PIPELINES_TOKEN: ${{ inputs.pipelines_token }}
         PIPELINES_AUTH_ROLE: ${{ inputs.pipelines_auth_role }}
       run: |
-        if [[ $PRESIGN_TOKEN != "true" ]]; then
-          exit 0
-        fi
-        if [[ $PIPELINES_TOKEN == "" ]]; then
-          echo "Presign token is true, but pipelines token is not set."
-          echo "The pipelines token is required to download the pipelines binary to presign the `GetCallerIdentity` request."
+        if [[ "$INSTALL_PIPELINES_CLI" == "true" && -z "$PIPELINES_TOKEN" ]]; then
+          echo "ERROR: You must provide a GitHub token for downloading the Gruntwork Pipelines CLI"
           exit 1
         fi
-        if [[ $PIPELINES_AUTH_ROLE == "" ]]; then
-          echo "Presign token is true, but pipelines auth role is not set."
-          echo "The pipelines auth role is required to authenticate the calling repo to the infrastructure-pipelines repo."
+
+        if [[ "$ASSUME_PIPELINES_AUTH_ROLE" == "true" && -z "$PIPELINES_AUTH_ROLE" ]]; then
+          echo "ERROR: You must provide a role to assume before running `pipelines auth presign`"
           exit 1
         fi
 
@@ -105,7 +111,7 @@ runs:
     # install the CLI before running this action, in which case we don't need
     # to do it here.
     - name: Download Pipelines CLI
-      if: ${{ inputs.presign_token == 'true' && inputs.pipelines_token != '' }}
+      if: ${{ inputs.presign_token == 'true' && inputs.install_pipelines_cli == 'true' }}
       uses: dsaltares/fetch-gh-release-asset@1.1.1
       with:
         repo: "gruntwork-io/pipelines-cli"
@@ -115,7 +121,7 @@ runs:
         token: ${{ inputs.pipelines_token }}
 
     - name: Install Pipelines CLI
-      if: ${{ inputs.presign_token == 'true' && inputs.pipelines_token != '' }}
+      if: ${{ inputs.presign_token == 'true' && inputs.install_pipelines_cli == 'true' }}
       shell: bash
       run: |
         sudo mv /tmp/pipelines /usr/local/bin/pipelines
@@ -125,7 +131,7 @@ runs:
       # and we have a role to assume to do so. Clients might decide to assume a role before
       # running this action, in which case we don't need to do it here.
     - name: Authenticate with AWS
-      if: ${{ inputs.presign_token == 'true' && inputs.pipelines_auth_role != '' }}
+      if: ${{ inputs.presign_token == 'true' && inputs.assume_pipelines_auth_role == 'true' }}
       uses: aws-actions/configure-aws-credentials@v4
       with:
         role-to-assume: arn:aws:iam::${{ inputs.account_id }}:role/${{ inputs.pipelines_auth_role }}

--- a/scripts/setup-action-configs.sh
+++ b/scripts/setup-action-configs.sh
@@ -3,8 +3,6 @@
 set -euo pipefail
 IFS=$'\n\t'
 
-set -x
-
 # Required environment variables
 : "${CHANGE_TYPE:? "CHANGE_TYPE environment variable must be set"}"
 : "${MANAGEMENT_ACCOUNT:? "MANAGEMENT_ACCOUNT environment variable must be set"}"
@@ -38,7 +36,7 @@ append_presigned_caller_identity_token() {
     readonly workflow_inputs="$1"
 
     presigned_caller_identity="$(presign_caller_identity_token)"
-    echo "$workflow_inputs" | jq --arg presigned_caller_identity "$presigned_caller_identity" '. + {presigned_caller_identity: $presigned_caller_identity}'
+    echo "$workflow_inputs" | jq -c --arg presigned_caller_identity "$presigned_caller_identity" '. + {presigned_caller_identity: $presigned_caller_identity}'
 }
 
 handle_account_request() {

--- a/scripts/setup-action-configs.sh
+++ b/scripts/setup-action-configs.sh
@@ -36,7 +36,7 @@ append_presigned_caller_identity_token() {
     readonly workflow_inputs="$1"
 
     presigned_caller_identity="$(presign_caller_identity_token)"
-    jq --arg presigned_caller_identity "$presigned_caller_identity" '. + {presigned_caller_identity: $presigned_caller_identity}' <<< "$workflow_inputs"
+    echo "$workflow_inputs" | jq --arg presigned_caller_identity "$presigned_caller_identity" '. + {presigned_caller_identity: $presigned_caller_identity}'
 }
 
 handle_account_request() {

--- a/scripts/setup-action-configs.sh
+++ b/scripts/setup-action-configs.sh
@@ -175,6 +175,7 @@ handle_default() {
     readonly terragrunt_command="$5"
     readonly pipelines_change_type="$6"
     readonly child_account_id="$7"
+    readonly presign_token="$8"
 
     echo "workflow=terragrunt-executor.yml" >> "$GITHUB_OUTPUT"
     workflow_inputs=$(jq -c -n \

--- a/scripts/setup-action-configs.sh
+++ b/scripts/setup-action-configs.sh
@@ -16,7 +16,7 @@ IFS=$'\n\t'
 NEW_ACCOUNT_NAME="${NEW_ACCOUNT_NAME:-}"
 TEAM_ACCOUNT_NAMES="${TEAM_ACCOUNT_NAMES:-}"
 CHILD_ACCOUNT_ID="${CHILD_ACCOUNT_ID:-}"
-PIPELINES_AUTH_ROLE="${PIPELINES_AUTH_ROLE:-}"
+PRESIGN_TOKEN="${PRESIGN_TOKEN:-false}"
 TEAM_ACCOUNT_DATA="${TEAM_ACCOUNT_DATA:-}"
 
 check_pipeline_is_installed() {
@@ -46,7 +46,7 @@ handle_account_request() {
     readonly infra_live_repo="$4"
     readonly working_directory="$5"
     readonly terragrunt_command="$6"
-    readonly pipelines_auth_role="$7"
+    readonly presign_token="$7"
 
     echo "workflow=create-account-and-generate-baselines.yml" >> "$GITHUB_OUTPUT"
     workflow_inputs="$(jq -c -n \
@@ -65,7 +65,7 @@ handle_account_request() {
             "terragrunt_command": $terragrunt_command
         }'
     )"
-    if [[ -n "${pipelines_auth_role:-}" ]]; then
+    if [[ $presign_token == "true" ]]; then
         workflow_inputs="$(append_presigned_caller_identity_token "$workflow_inputs")"
     fi
     echo "workflow_inputs=$workflow_inputs" >> "$GITHUB_OUTPUT"
@@ -78,7 +78,7 @@ handle_account_added() {
     readonly infra_live_repo="$4"
     readonly working_directory="$5"
     readonly terragrunt_command="$6"
-    readonly pipelines_auth_role="$7"
+    readonly presign_token="$7"
 
     echo "workflow=apply-new-account-baseline.yml" >> "$GITHUB_OUTPUT"
     workflow_inputs="$(jq -c -n \
@@ -97,7 +97,7 @@ handle_account_added() {
             "terragrunt_command": $terragrunt_command
         }'
     )"
-    if [[ -n "${pipelines_auth_role:-}" ]]; then
+    if [[ $presign_token == "true" ]]; then
         workflow_inputs="$(append_presigned_caller_identity_token "$workflow_inputs")"
     fi
     echo "workflow_inputs=$workflow_inputs" >> "$GITHUB_OUTPUT"
@@ -110,7 +110,7 @@ handle_team_accounts_requested() {
     readonly working_directory="$4"
     readonly terragrunt_command="$5"
     readonly team_account_names="$6"
-    readonly pipelines_auth_role="$7"
+    readonly presign_token="$7"
 
     echo "workflow=create-sdlc-accounts-and-generate-baselines.yml" >> "$GITHUB_OUTPUT"
     workflow_inputs="$(jq -c -n \
@@ -129,7 +129,7 @@ handle_team_accounts_requested() {
             "team_account_names": $team_account_names
         }'
     )"
-    if [[ -n "${pipelines_auth_role:-}" ]]; then
+    if [[ $presign_token == "true" ]]; then
         workflow_inputs="$(append_presigned_caller_identity_token "$workflow_inputs")"
     fi
     echo "workflow_inputs=$workflow_inputs" >> "$GITHUB_OUTPUT"
@@ -142,7 +142,7 @@ handle_team_accounts_added() {
     readonly working_directory="$4"
     readonly terragrunt_command="$5"
     readonly team_account_data="$6"
-    readonly pipelines_auth_role="$7"
+    readonly presign_token="$7"
 
     echo "workflow=apply-new-sdlc-accounts-baseline.yml" >> "$GITHUB_OUTPUT"
     workflow_inputs=$(jq -c -n \
@@ -161,7 +161,7 @@ handle_team_accounts_added() {
             "team_account_data": $team_account_data
         }'
     )
-    if [[ -n "${pipelines_auth_role:-}" ]]; then
+    if [[ $presign_token == "true" ]]; then
         workflow_inputs="$(append_presigned_caller_identity_token "$workflow_inputs")"
     fi
     echo "workflow_inputs=$workflow_inputs" >> "$GITHUB_OUTPUT"
@@ -195,7 +195,7 @@ handle_default() {
             "child_account_id": $child_account_id
         }'
     )
-    if [[ -n "${pipelines_auth_role:-}" ]]; then
+    if [[ $presign_token == "true" ]]; then
         workflow_inputs="$(append_presigned_caller_identity_token "$workflow_inputs")"
     fi
     echo "workflow_inputs=$workflow_inputs" >> "$GITHUB_OUTPUT"
@@ -203,18 +203,18 @@ handle_default() {
 
 case "$CHANGE_TYPE" in
     AccountRequested)
-        handle_account_request "$MANAGEMENT_ACCOUNT" "$NEW_ACCOUNT_NAME" "$BRANCH" "$INFRA_LIVE_REPO" "$WORKING_DIRECTORY" "$COMMAND $ARGS" "$PIPELINES_AUTH_ROLE"
+        handle_account_request "$MANAGEMENT_ACCOUNT" "$NEW_ACCOUNT_NAME" "$BRANCH" "$INFRA_LIVE_REPO" "$WORKING_DIRECTORY" "$COMMAND $ARGS" "$PRESIGN_TOKEN"
         ;;
     AccountAdded)
-        handle_account_added "$MANAGEMENT_ACCOUNT" "$NEW_ACCOUNT_NAME" "$BRANCH" "$INFRA_LIVE_REPO" "$WORKING_DIRECTORY" "$COMMAND $ARGS" "$PIPELINES_AUTH_ROLE"
+        handle_account_added "$MANAGEMENT_ACCOUNT" "$NEW_ACCOUNT_NAME" "$BRANCH" "$INFRA_LIVE_REPO" "$WORKING_DIRECTORY" "$COMMAND $ARGS" "$PRESIGN_TOKEN"
         ;;
     TeamAccountsRequested)
-        handle_team_accounts_requested "$MANAGEMENT_ACCOUNT" "$BRANCH" "$INFRA_LIVE_REPO" "$WORKING_DIRECTORY" "$COMMAND $ARGS" "$TEAM_ACCOUNT_NAMES" "$PIPELINES_AUTH_ROLE"
+        handle_team_accounts_requested "$MANAGEMENT_ACCOUNT" "$BRANCH" "$INFRA_LIVE_REPO" "$WORKING_DIRECTORY" "$COMMAND $ARGS" "$TEAM_ACCOUNT_NAMES" "$PRESIGN_TOKEN"
         ;;
     TeamAccountsAdded)
-        handle_team_accounts_added "$MANAGEMENT_ACCOUNT" "$BRANCH" "$INFRA_LIVE_REPO" "$WORKING_DIRECTORY" "$COMMAND $ARGS" "$TEAM_ACCOUNT_DATA" "$PIPELINES_AUTH_ROLE"
+        handle_team_accounts_added "$MANAGEMENT_ACCOUNT" "$BRANCH" "$INFRA_LIVE_REPO" "$WORKING_DIRECTORY" "$COMMAND $ARGS" "$TEAM_ACCOUNT_DATA" "$PRESIGN_TOKEN"
         ;;
     *)
-        handle_default "$MANAGEMENT_ACCOUNT" "$BRANCH" "$INFRA_LIVE_REPO" "$WORKING_DIRECTORY" "$COMMAND $ARGS" "$CHANGE_TYPE" "$CHILD_ACCOUNT_ID" "$PIPELINES_AUTH_ROLE"
+        handle_default "$MANAGEMENT_ACCOUNT" "$BRANCH" "$INFRA_LIVE_REPO" "$WORKING_DIRECTORY" "$COMMAND $ARGS" "$CHANGE_TYPE" "$CHILD_ACCOUNT_ID" "$PRESIGN_TOKEN"
         ;;
 esac

--- a/scripts/setup-action-configs.sh
+++ b/scripts/setup-action-configs.sh
@@ -31,6 +31,13 @@ presign_caller_identity_token() {
     pipelines auth presign
 }
 
+append_presigned_caller_identity_token() {
+    readonly workflow_inputs="$1"
+
+    presigned_caller_identity="$(presign_caller_identity_token)"
+    jq --arg presigned_caller_identity "$presigned_caller_identity" '. + {presigned_caller_identity: $presigned_caller_identity}' <<< "$workflow_inputs"
+}
+
 handle_account_request() {
     readonly management_account="$1"
     readonly new_account_name="$2"
@@ -58,8 +65,7 @@ handle_account_request() {
         }'
     )"
     if [[ -n "$pipelines_auth_role" ]]; then
-        presigned_caller_identity="$(presign_caller_identity_token)"
-        workflow_inputs="$(jq --arg presigned_caller_identity "$presigned_caller_identity" '. + {presigned_caller_identity: $presigned_caller_identity}' <<< "$workflow_inputs")"
+        workflow_inputs="$(append_presigned_caller_identity_token "$workflow_inputs")"
     fi
     echo "workflow_inputs=$workflow_inputs" >> "$GITHUB_OUTPUT"
 }
@@ -91,8 +97,7 @@ handle_account_added() {
         }'
     )"
     if [[ -n "$pipelines_auth_role" ]]; then
-        presigned_caller_identity="$(presign_caller_identity_token)"
-        workflow_inputs="$(jq --arg presigned_caller_identity "$presigned_caller_identity" '. + {presigned_caller_identity: $presigned_caller_identity}' <<< "$workflow_inputs")"
+        workflow_inputs="$(append_presigned_caller_identity_token "$workflow_inputs")"
     fi
     echo "workflow_inputs=$workflow_inputs" >> "$GITHUB_OUTPUT"
 }
@@ -122,8 +127,7 @@ handle_team_accounts_requested() {
         }'
     )"
     if [[ -n "$pipelines_auth_role" ]]; then
-        presigned_caller_identity="$(presign_caller_identity_token)"
-        workflow_inputs="$(jq --arg presigned_caller_identity "$presigned_caller_identity" '. + {presigned_caller_identity: $presigned_caller_identity}' <<< "$workflow_inputs")"
+        workflow_inputs="$(append_presigned_caller_identity_token "$workflow_inputs")"
     fi
     echo "workflow_inputs=$workflow_inputs" >> "$GITHUB_OUTPUT"
 }
@@ -155,8 +159,7 @@ handle_team_accounts_added() {
         }'
     )
     if [[ -n "$pipelines_auth_role" ]]; then
-        presigned_caller_identity="$(presign_caller_identity_token)"
-        workflow_inputs="$(jq --arg presigned_caller_identity "$presigned_caller_identity" '. + {presigned_caller_identity: $presigned_caller_identity}' <<< "$workflow_inputs")"
+        workflow_inputs="$(append_presigned_caller_identity_token "$workflow_inputs")"
     fi
     echo "workflow_inputs=$workflow_inputs" >> "$GITHUB_OUTPUT"
 }
@@ -190,8 +193,7 @@ handle_default() {
         }'
     )
     if [[ -n "$pipelines_auth_role" ]]; then
-        presigned_caller_identity="$(presign_caller_identity_token)"
-        workflow_inputs="$(jq --arg presigned_caller_identity "$presigned_caller_identity" '. + {presigned_caller_identity: $presigned_caller_identity}' <<< "$workflow_inputs")"
+        workflow_inputs="$(append_presigned_caller_identity_token "$workflow_inputs")"
     fi
     echo "workflow_inputs=$workflow_inputs" >> "$GITHUB_OUTPUT"
 }

--- a/scripts/setup-action-configs.sh
+++ b/scripts/setup-action-configs.sh
@@ -1,0 +1,215 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+IFS=$'\n\t'
+
+# Required environment variables
+: "${CHANGE_TYPE:? "CHANGE_TYPE environment variable must be set"}"
+: "${MANAGEMENT_ACCOUNT:? "MANAGEMENT_ACCOUNT environment variable must be set"}"
+: "${BRANCH:? "BRANCH environment variable must be set"}"
+: "${INFRA_LIVE_REPO:? "INFRA_LIVE_REPO environment variable must be set"}"
+: "${WORKING_DIRECTORY:? "WORKING_DIRECTORY environment variable must be set"}"
+: "${COMMAND:? "COMMAND environment variable must be set"}"
+: "${ARGS:? "ARGS environment variable must be set"}"
+
+# Optional environment variables
+NEW_ACCOUNT_NAME="${NEW_ACCOUNT_NAME:-}"
+TEAM_ACCOUNT_NAMES="${TEAM_ACCOUNT_NAMES:-}"
+CHILD_ACCOUNT_ID="${CHILD_ACCOUNT_ID:-}"
+PIPELINES_AUTH_ROLE="${PIPELINES_AUTH_ROLE:-}"
+
+check_pipeline_is_installed() {
+    if ! command -v pipelines &> /dev/null; then
+        echo "pipelines CLI not installed"
+        exit 1
+    fi
+}
+
+presign_caller_identity_token() {
+    check_pipeline_is_installed
+
+    pipelines auth presign
+}
+
+handle_account_request() {
+    readonly management_account="$1"
+    readonly new_account_name="$2"
+    readonly branch="$3"
+    readonly infra_live_repo="$4"
+    readonly working_directory="$5"
+    readonly terragrunt_command="$6"
+    readonly pipelines_auth_role="$7"
+
+    echo "workflow=create-account-and-generate-baselines.yml" >> "$GITHUB_OUTPUT"
+    workflow_inputs="$(jq -c -n \
+        --arg management_account "$management_account" \
+        --arg new_account_name "$new_account_name" \
+        --arg branch "$branch" \
+        --arg infra_live_repo "$infra_live_repo" \
+        --arg working_directory "$working_directory" \
+        --arg terragrunt_command "$terragrunt_command" \
+        '{
+            "management_account": $management_account,
+            "new_account_name": $new_account_name,
+            "branch": $branch,
+            "infra_live_repo": $infra_live_repo,
+            "working_directory": $working_directory,
+            "terragrunt_command": $terragrunt_command
+        }'
+    )"
+    if [[ -n "$pipelines_auth_role" ]]; then
+        presigned_caller_identity="$(presign_caller_identity_token)"
+        workflow_inputs="$(jq --arg presigned_caller_identity "$presigned_caller_identity" '. + {presigned_caller_identity: $presigned_caller_identity}' <<< "$workflow_inputs")"
+    fi
+    echo "workflow_inputs=$workflow_inputs" >> "$GITHUB_OUTPUT"
+}
+
+handle_account_added() {
+    readonly management_account="$1"
+    readonly new_account_name="$2"
+    readonly branch="$3"
+    readonly infra_live_repo="$4"
+    readonly working_directory="$5"
+    readonly terragrunt_command="$6"
+    readonly pipelines_auth_role="$7"
+
+    echo "workflow=apply-new-account-baseline.yml" >> "$GITHUB_OUTPUT"
+    workflow_inputs="$(jq -c -n \
+        --arg management_account "$management_account" \
+        --arg new_account_name "$new_account_name" \
+        --arg branch "$branch" \
+        --arg infra_live_repo "$infra_live_repo" \
+        --arg working_directory "$working_directory" \
+        --arg terragrunt_command "$terragrunt_command" \
+        '{
+            "management_account": $management_account,
+            "new_account_name": $new_account_name,
+            "branch": $branch,
+            "infra_live_repo": $infra_live_repo,
+            "working_directory": $working_directory,
+            "terragrunt_command": $terragrunt_command
+        }'
+    )"
+    if [[ -n "$pipelines_auth_role" ]]; then
+        presigned_caller_identity="$(presign_caller_identity_token)"
+        workflow_inputs="$(jq --arg presigned_caller_identity "$presigned_caller_identity" '. + {presigned_caller_identity: $presigned_caller_identity}' <<< "$workflow_inputs")"
+    fi
+    echo "workflow_inputs=$workflow_inputs" >> "$GITHUB_OUTPUT"
+}
+
+handle_team_accounts_requested() {
+    readonly management_account="$1"
+    readonly branch="$2"
+    readonly infra_live_repo="$3"
+    readonly working_directory="$4"
+    readonly terragrunt_command="$5"
+    readonly team_account_names="$6"
+    readonly pipelines_auth_role="$7"
+
+    echo "workflow=create-sdlc-accounts-and-generate-baselines.yml" >> "$GITHUB_OUTPUT"
+    workflow_inputs="$(jq -c -n \
+        --arg management_account "$management_account" \
+        --arg branch "$branch" \
+        --arg infra_live_repo "$infra_live_repo" \
+        --arg working_directory "$working_directory" \
+        --arg terragrunt_command "$terragrunt_command" \
+        '{
+            "management_account": $management_account,
+            "branch": $branch,
+            "infra_live_repo": $infra_live_repo,
+            "working_directory": $working_directory,
+            "terragrunt_command": $terragrunt_command
+        }'
+    )"
+    if [[ -n "$pipelines_auth_role" ]]; then
+        presigned_caller_identity="$(presign_caller_identity_token)"
+        workflow_inputs="$(jq --arg presigned_caller_identity "$presigned_caller_identity" '. + {presigned_caller_identity: $presigned_caller_identity}' <<< "$workflow_inputs")"
+    fi
+    echo "workflow_inputs=$workflow_inputs" >> "$GITHUB_OUTPUT"
+}
+
+handle_team_accounts_added() {
+    readonly management_account="$1"
+    readonly branch="$2"
+    readonly infra_live_repo="$3"
+    readonly working_directory="$4"
+    readonly terragrunt_command="$5"
+    readonly team_account_names="$6"
+    readonly pipelines_auth_role="$7"
+
+    echo "workflow=apply-new-sdlc-accounts-baseline.yml" >> "$GITHUB_OUTPUT"
+    workflow_inputs=$(jq -c -n \
+        --arg management_account "$management_account" \
+        --arg branch "$branch" \
+        --arg infra_live_repo "$infra_live_repo" \
+        --arg working_directory "$working_directory" \
+        --arg terragrunt_command "$terragrunt_command" \
+        --arg team_account_names "$team_account_names" \
+        '{
+            "management_account": $management_account,
+            "branch": $branch,
+            "infra_live_repo": $infra_live_repo,
+            "working_directory": $working_directory,
+            "terragrunt_command": $terragrunt_command,
+            "team_account_names": $team_account_names
+        }'
+    )
+    if [[ -n "$pipelines_auth_role" ]]; then
+        presigned_caller_identity="$(presign_caller_identity_token)"
+        workflow_inputs="$(jq --arg presigned_caller_identity "$presigned_caller_identity" '. + {presigned_caller_identity: $presigned_caller_identity}' <<< "$workflow_inputs")"
+    fi
+    echo "workflow_inputs=$workflow_inputs" >> "$GITHUB_OUTPUT"
+}
+
+handle_default() {
+    readonly management_account="$1"
+    readonly branch="$2"
+    readonly infra_live_repo="$3"
+    readonly working_directory="$4"
+    readonly terragrunt_command="$5"
+    readonly pipelines_change_type="$6"
+    readonly child_account_id="$7"
+
+    echo "workflow=terragrunt-executor.yml" >> "$GITHUB_OUTPUT"
+    workflow_inputs=$(jq -c -n \
+        --arg account "$management_account" \
+        --arg branch "$branch" \
+        --arg infra_live_repo "$infra_live_repo" \
+        --arg working_directory "$working_directory" \
+        --arg terragrunt_command "$terragrunt_command" \
+        --arg pipelines_change_type "$pipelines_change_type" \
+        --arg child_account_id "$child_account_id" \
+        '{
+            "account": $account,
+            "branch": $branch,
+            "infra_live_repo": $infra_live_repo,
+            "working_directory": $working_directory,
+            "terragrunt_command": $terragrunt_command,
+            "pipelines_change_type": $pipelines_change_type,
+            "child_account_id": $child_account_id
+        }'
+    )
+    if [[ -n "$pipelines_auth_role" ]]; then
+        presigned_caller_identity="$(presign_caller_identity_token)"
+        workflow_inputs="$(jq --arg presigned_caller_identity "$presigned_caller_identity" '. + {presigned_caller_identity: $presigned_caller_identity}' <<< "$workflow_inputs")"
+    fi
+    echo "workflow_inputs=$workflow_inputs" >> "$GITHUB_OUTPUT"
+}
+
+case "$CHANGE_TYPE" in
+    AccountRequested)
+        handle_account_request "$MANAGEMENT_ACCOUNT" "$NEW_ACCOUNT_NAME" "$BRANCH" "$INFRA_LIVE_REPO" "$WORKING_DIRECTORY" "$COMMAND $ARGS" "$PIPELINES_AUTH_ROLE"
+        ;;
+    AccountAdded)
+        handle_account_added "$MANAGEMENT_ACCOUNT" "$NEW_ACCOUNT_NAME" "$BRANCH" "$INFRA_LIVE_REPO" "$WORKING_DIRECTORY" "$COMMAND $ARGS" "$PIPELINES_AUTH_ROLE"
+        ;;
+    TeamAccountsRequested)
+        handle_team_accounts_requested "$MANAGEMENT_ACCOUNT" "$BRANCH" "$INFRA_LIVE_REPO" "$WORKING_DIRECTORY" "$COMMAND $ARGS" "$TEAM_ACCOUNT_NAMES" "$PIPELINES_AUTH_ROLE"
+        ;;
+    TeamAccountsAdded)
+        handle_team_accounts_added "$MANAGEMENT_ACCOUNT" "$BRANCH" "$INFRA_LIVE_REPO" "$WORKING_DIRECTORY" "$COMMAND $ARGS" "$TEAM_ACCOUNT_NAMES" "$PIPELINES_AUTH_ROLE"
+        ;;
+    *)
+        handle_default "$MANAGEMENT_ACCOUNT" "$BRANCH" "$INFRA_LIVE_REPO" "$WORKING_DIRECTORY" "$COMMAND $ARGS" "$CHANGE_TYPE" "$CHILD_ACCOUNT_ID" "$PIPELINES_AUTH_ROLE"
+        ;;
+esac

--- a/scripts/setup-action-configs.sh
+++ b/scripts/setup-action-configs.sh
@@ -17,6 +17,7 @@ NEW_ACCOUNT_NAME="${NEW_ACCOUNT_NAME:-}"
 TEAM_ACCOUNT_NAMES="${TEAM_ACCOUNT_NAMES:-}"
 CHILD_ACCOUNT_ID="${CHILD_ACCOUNT_ID:-}"
 PIPELINES_AUTH_ROLE="${PIPELINES_AUTH_ROLE:-}"
+TEAM_ACCOUNT_DATA="${TEAM_ACCOUNT_DATA:-}"
 
 check_pipeline_is_installed() {
     if ! command -v pipelines &> /dev/null; then
@@ -72,7 +73,7 @@ handle_account_request() {
 
 handle_account_added() {
     readonly management_account="$1"
-    readonly new_account_name="$2"
+    readonly child_account="$2"
     readonly branch="$3"
     readonly infra_live_repo="$4"
     readonly working_directory="$5"
@@ -82,14 +83,14 @@ handle_account_added() {
     echo "workflow=apply-new-account-baseline.yml" >> "$GITHUB_OUTPUT"
     workflow_inputs="$(jq -c -n \
         --arg management_account "$management_account" \
-        --arg new_account_name "$new_account_name" \
+        --arg child_account "$child_account" \
         --arg branch "$branch" \
         --arg infra_live_repo "$infra_live_repo" \
         --arg working_directory "$working_directory" \
         --arg terragrunt_command "$terragrunt_command" \
         '{
             "management_account": $management_account,
-            "new_account_name": $new_account_name,
+            "child_account": $child_account,
             "branch": $branch,
             "infra_live_repo": $infra_live_repo,
             "working_directory": $working_directory,
@@ -118,12 +119,14 @@ handle_team_accounts_requested() {
         --arg infra_live_repo "$infra_live_repo" \
         --arg working_directory "$working_directory" \
         --arg terragrunt_command "$terragrunt_command" \
+        --arg team_account_names "$team_account_names" \
         '{
             "management_account": $management_account,
             "branch": $branch,
             "infra_live_repo": $infra_live_repo,
             "working_directory": $working_directory,
-            "terragrunt_command": $terragrunt_command
+            "terragrunt_command": $terragrunt_command,
+            "team_account_names": $team_account_names
         }'
     )"
     if [[ -n "${pipelines_auth_role:-}" ]]; then
@@ -138,7 +141,7 @@ handle_team_accounts_added() {
     readonly infra_live_repo="$3"
     readonly working_directory="$4"
     readonly terragrunt_command="$5"
-    readonly team_account_names="$6"
+    readonly team_account_data="$6"
     readonly pipelines_auth_role="$7"
 
     echo "workflow=apply-new-sdlc-accounts-baseline.yml" >> "$GITHUB_OUTPUT"
@@ -148,14 +151,14 @@ handle_team_accounts_added() {
         --arg infra_live_repo "$infra_live_repo" \
         --arg working_directory "$working_directory" \
         --arg terragrunt_command "$terragrunt_command" \
-        --arg team_account_names "$team_account_names" \
+        --arg team_account_data "$team_account_data" \
         '{
             "management_account": $management_account,
             "branch": $branch,
             "infra_live_repo": $infra_live_repo,
             "working_directory": $working_directory,
             "terragrunt_command": $terragrunt_command,
-            "team_account_names": $team_account_names
+            "team_account_data": $team_account_data
         }'
     )
     if [[ -n "${pipelines_auth_role:-}" ]]; then
@@ -209,7 +212,7 @@ case "$CHANGE_TYPE" in
         handle_team_accounts_requested "$MANAGEMENT_ACCOUNT" "$BRANCH" "$INFRA_LIVE_REPO" "$WORKING_DIRECTORY" "$COMMAND $ARGS" "$TEAM_ACCOUNT_NAMES" "$PIPELINES_AUTH_ROLE"
         ;;
     TeamAccountsAdded)
-        handle_team_accounts_added "$MANAGEMENT_ACCOUNT" "$BRANCH" "$INFRA_LIVE_REPO" "$WORKING_DIRECTORY" "$COMMAND $ARGS" "$TEAM_ACCOUNT_NAMES" "$PIPELINES_AUTH_ROLE"
+        handle_team_accounts_added "$MANAGEMENT_ACCOUNT" "$BRANCH" "$INFRA_LIVE_REPO" "$WORKING_DIRECTORY" "$COMMAND $ARGS" "$TEAM_ACCOUNT_DATA" "$PIPELINES_AUTH_ROLE"
         ;;
     *)
         handle_default "$MANAGEMENT_ACCOUNT" "$BRANCH" "$INFRA_LIVE_REPO" "$WORKING_DIRECTORY" "$COMMAND $ARGS" "$CHANGE_TYPE" "$CHILD_ACCOUNT_ID" "$PIPELINES_AUTH_ROLE"

--- a/scripts/setup-action-configs.sh
+++ b/scripts/setup-action-configs.sh
@@ -3,6 +3,8 @@
 set -euo pipefail
 IFS=$'\n\t'
 
+set -x
+
 # Required environment variables
 : "${CHANGE_TYPE:? "CHANGE_TYPE environment variable must be set"}"
 : "${MANAGEMENT_ACCOUNT:? "MANAGEMENT_ACCOUNT environment variable must be set"}"

--- a/scripts/setup-action-configs.sh
+++ b/scripts/setup-action-configs.sh
@@ -64,7 +64,7 @@ handle_account_request() {
             "terragrunt_command": $terragrunt_command
         }'
     )"
-    if [[ -n "$pipelines_auth_role" ]]; then
+    if [[ -n "${pipelines_auth_role:-}" ]]; then
         workflow_inputs="$(append_presigned_caller_identity_token "$workflow_inputs")"
     fi
     echo "workflow_inputs=$workflow_inputs" >> "$GITHUB_OUTPUT"
@@ -96,7 +96,7 @@ handle_account_added() {
             "terragrunt_command": $terragrunt_command
         }'
     )"
-    if [[ -n "$pipelines_auth_role" ]]; then
+    if [[ -n "${pipelines_auth_role:-}" ]]; then
         workflow_inputs="$(append_presigned_caller_identity_token "$workflow_inputs")"
     fi
     echo "workflow_inputs=$workflow_inputs" >> "$GITHUB_OUTPUT"
@@ -126,7 +126,7 @@ handle_team_accounts_requested() {
             "terragrunt_command": $terragrunt_command
         }'
     )"
-    if [[ -n "$pipelines_auth_role" ]]; then
+    if [[ -n "${pipelines_auth_role:-}" ]]; then
         workflow_inputs="$(append_presigned_caller_identity_token "$workflow_inputs")"
     fi
     echo "workflow_inputs=$workflow_inputs" >> "$GITHUB_OUTPUT"
@@ -158,7 +158,7 @@ handle_team_accounts_added() {
             "team_account_names": $team_account_names
         }'
     )
-    if [[ -n "$pipelines_auth_role" ]]; then
+    if [[ -n "${pipelines_auth_role:-}" ]]; then
         workflow_inputs="$(append_presigned_caller_identity_token "$workflow_inputs")"
     fi
     echo "workflow_inputs=$workflow_inputs" >> "$GITHUB_OUTPUT"
@@ -192,7 +192,7 @@ handle_default() {
             "child_account_id": $child_account_id
         }'
     )
-    if [[ -n "$pipelines_auth_role" ]]; then
+    if [[ -n "${pipelines_auth_role:-}" ]]; then
         workflow_inputs="$(append_presigned_caller_identity_token "$workflow_inputs")"
     fi
     echo "workflow_inputs=$workflow_inputs" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
I started setting up this action for testing `pipelines auth presign`, which can be mocked with fake AWS credentials, as the AWS SDK will accept dummy values for credentials, and presign a request accordingly, but we will need to associate a token with the repo for downloading the pipelines CLI. 

Will reach out to team for commentary before proceeding.

