### PR TITLE
Updating pipelines cli default version to v0.4.0

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -75,7 +75,7 @@ inputs:
   pipelines_cli_version:
     description: "The version of the Gruntwork Pipelines CLI to use"
     required: false
-    default: "0.4.0"
+    default: "v0.4.0"
   pipelines_auth_role:
     description: "The role to assume before running `pipelines auth presign`, which is used to authenticate the calling repo. Only necessary when pipelines auth role is provisioned and checked in infrastructure-pipelines repo."
     required: false


### PR DESCRIPTION
With the leading `v` missing, installs were failing using the default.