### PR TITLE
Fixing usage of `TeamAccountNames` in `additional_data`

### DIFF
--- a/.github/workflows/create-sdlc-accounts-and-generate-baselines.yml
+++ b/.github/workflows/create-sdlc-accounts-and-generate-baselines.yml
@@ -88,7 +88,7 @@ jobs:
             exit 1
           fi
 
-          if [[ $(jq -c -M  <<< "$TEAM_ACCOUNT_NAMES") != '["team_account_names"]' ]]; then
+          if [[ $(jq -c -M  <<< "$TEAM_ACCOUNT_NAMES") != '"team_account_name_one,team_account_name_two"' ]]; then
             echo "TEAM_ACCOUNT_NAMES is not set to expected value"
             exit 1
           fi

--- a/.github/workflows/test-caller.yml
+++ b/.github/workflows/test-caller.yml
@@ -70,7 +70,7 @@ jobs:
             {
               "AccountName": "new_account_name",
               "ChildAccountId": "child_account_id",
-              "TeamAccountNames": ["team_account_names"]
+              "TeamAccountNames": "team_account_name_one,team_account_name_two"
             }
           actor: "actor"
           presign_token: ${{ matrix.presign }}

--- a/action.yml
+++ b/action.yml
@@ -151,7 +151,7 @@ runs:
         ARGS: ${{ inputs.args }}
         CHILD_ACCOUNT_ID: ${{ fromJSON(inputs.additional_data).ChildAccountId }}
         PRESIGN_TOKEN: ${{ inputs.presign_token }}
-        TEAM_ACCOUNT_NAMES: "${{ toJSON(fromJSON(inputs.additional_data).TeamAccountNames) }}"
+        TEAM_ACCOUNT_NAMES: ${{ fromJSON(inputs.additional_data).TeamAccountNames }}
         TEAM_ACCOUNT_DATA: ${{ inputs.additional_data }}
         ACTION_PATH: ${{ github.action_path }}
       # We need this magic value found here:


### PR DESCRIPTION
This action was using the incrrect assumption that the `TeamAccountNames` field of `additional_data` was a JSON array instead of a comma separated list in a string.

This fixes that assumption.

